### PR TITLE
rmw.c:change message when insufficient options are given [skip ci]

### DIFF
--- a/src/rmw.c
+++ b/src/rmw.c
@@ -487,7 +487,7 @@ Please check your configuration file and permissions\n\n"));
   }
   else if (!cli_user_options.want_purge && !cli_user_options.want_empty_trash && created_data_dir != FIRST_RUN)
   {
-    printf (_("Insufficient command line options or no filenames were given\n\
+    printf (_("Insufficient command line arguments given;\n\
 Enter '%s -h' for more information\n"), argv[0]);
   }
 

--- a/src/rmw.c
+++ b/src/rmw.c
@@ -487,10 +487,7 @@ Please check your configuration file and permissions\n\n"));
   }
   else if (!cli_user_options.want_purge && !cli_user_options.want_empty_trash && created_data_dir != FIRST_RUN)
   {
-    if (force)
-      printf (_("'-f/--force' does nothing without '-g/--purge'\n"));
-    else
-      printf (_("No filenames or command line options were given\n\
+    printf (_("Insufficient command line options or no filenames were given\n\
 Enter '%s -h' for more information\n"), argv[0]);
   }
 

--- a/test/purging.sh.in
+++ b/test/purging.sh.in
@@ -142,11 +142,6 @@ output=`echo "y" | $RMW_ALT_TEST_CMD_STRING --purge -e`
 test "$output" = "purge has been skipped: use -f or --force"
 test_result $?
 
-# echo " == Should not work if '--purge' isn't used"
-# output=`echo "y" | $RMW_ALT_TEST_CMD_STRING -ffe`
-# test "$output" = "'-f/--force' does nothing without '-g/--purge'"
-# test_result $?
-
 echo " == Should not work 'Y' or 'y' is not supplied."
 echo "yfw" | $RMW_TEST_CMD_STRING --purge -e
 test_result $?


### PR DESCRIPTION
Rmw would give this message if '-f' were used by itself, or '-v' and maybe in other cases too.