### PR TITLE
move other user option switches to cli_user_options.

### DIFF
--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -187,8 +187,8 @@ realize_home (char **str)
  * @return node containing information about the new WASTE folder, or \b waste_curr if no new folder was added.
  */
 static st_waste *
-parse_line_waste (st_waste * waste_curr, const char *line_from_config,
-                  bool * do_continue)
+parse_line_waste (st_waste * waste_curr, const char * line_from_config,
+                  bool * do_continue, const rmw_options * cli_user_options)
 {
   bool removable = 0;
 
@@ -224,8 +224,7 @@ parse_line_waste (st_waste * waste_curr, const char *line_from_config,
 
   if (removable && !exists (value))
   {
-    extern const bool list;
-    if (list)
+    if (cli_user_options->list)
     {
       /*
        * These lines are separated to ease translation
@@ -325,15 +324,14 @@ DO_CONT:
  *
  */
 static FILE *
-realize_config_file (char *config_file)
+realize_config_file (char *config_file, const rmw_options * cli_user_options)
 {
   if (verbose)
     printf ("sysconfdir = %s\n", SYSCONFDIR);
 
   extern const char *HOMEDIR;
-  extern const char *alt_config;
   /* If no alternate configuration was specifed (-c) */
-  if (alt_config == NULL)
+  if (cli_user_options->alt_config == NULL)
   {
     /**
      * CFG_FILE is the file name of the rmw config file relative to
@@ -346,8 +344,8 @@ realize_config_file (char *config_file)
   }
   else
   {
-    bufchk (alt_config, MP);
-    strcpy (config_file, alt_config);
+    bufchk (cli_user_options->alt_config, MP);
+    strcpy (config_file, cli_user_options->alt_config);
   }
 
 #define MSG_USING_CONFIG if (verbose) printf (_("config file: %s\n"), config_file)
@@ -428,7 +426,7 @@ realize_config_file (char *config_file)
  *
  */
 st_waste *
-get_config_data (void)
+get_config_data (const rmw_options * cli_user_options)
 {
   /*
    * The default value for purge_after is only used as a last resort,
@@ -439,8 +437,7 @@ get_config_data (void)
   extern bool force_required;
 
   char config_file[MP];
-  extern const char *alt_config;
-  FILE *config_ptr = realize_config_file (config_file);
+  FILE *config_ptr = realize_config_file (config_file, cli_user_options);
 
   st_waste *waste_head = NULL;
   st_waste *waste_curr = NULL;
@@ -475,7 +472,7 @@ get_config_data (void)
     else if (strncmp ("WASTE", line_from_config, 5) == 0)
     {
       waste_curr =
-        parse_line_waste (waste_curr, line_from_config, &do_continue);
+        parse_line_waste (waste_curr, line_from_config, &do_continue, cli_user_options);
       if (do_continue)
         continue;
     }

--- a/src/config_rmw.h
+++ b/src/config_rmw.h
@@ -44,4 +44,4 @@
 
 void translate_config (void);
 
-st_waste *get_config_data (void);
+st_waste *get_config_data (const rmw_options * cli_user_options);

--- a/src/purging_rmw.c
+++ b/src/purging_rmw.c
@@ -44,7 +44,7 @@ static off_t bytes_freed = 0;
  * @return error number
  */
 static int
-rmdir_recursive (char *path, short unsigned level)
+rmdir_recursive (char *path, short unsigned level, const rmw_options * cli_user_options)
 {
   if (level == RMDIR_MAX_DEPTH)
     return MAX_DEPTH_REACHED;
@@ -79,8 +79,7 @@ rmdir_recursive (char *path, short unsigned level)
     strcat (dir_path, entry->d_name);
 
     lstat (dir_path, &st);
-    extern const ushort force;
-    if (force == 2 && ~st.st_mode & S_IWUSR)
+    if (cli_user_options->force == 2 && ~st.st_mode & S_IWUSR)
     {
       if (!chmod (dir_path, 00700))
       {
@@ -118,7 +117,7 @@ rmdir_recursive (char *path, short unsigned level)
       else
       {
 
-        status = rmdir_recursive (dir_path, ++level);
+        status = rmdir_recursive (dir_path, ++level, cli_user_options);
         level--;
 
         switch (status)
@@ -348,7 +347,7 @@ purge (const st_waste * waste_curr, const rmw_options * cli_user_options)
         if (S_ISDIR (st.st_mode))
         {
           if (!cmd_dry_run)
-            status = rmdir_recursive (purgeFile, 1);
+            status = rmdir_recursive (purgeFile, 1, cli_user_options);
           else
           {
             /* Not much choice but to

--- a/src/rmw.c
+++ b/src/rmw.c
@@ -131,9 +131,6 @@ main (const int argc, char* const argv[])
   verbose = 0; /* already declared, a global */
   rmw_options cli_user_options;
   rmw_option_init (&cli_user_options);
-  bool want_orphan_chk = 0;
-  bool want_selection_menu = 0;
-  bool want_undo = 0;
 
   do
   {
@@ -160,16 +157,16 @@ main (const int argc, char* const argv[])
       cli_user_options.want_purge = true;
       break;
     case 'o':
-      want_orphan_chk = 1;
+      cli_user_options.want_orphan_chk = 1;
       break;
     case 'z':
       cli_user_options.want_restore = true;
       break;
     case 's':
-      want_selection_menu = 1;
+      cli_user_options.want_selection_menu = 1;
       break;
     case 'u':
-      want_undo = 1;
+      cli_user_options.want_undo = 1;
       break;
     case 'w':
       warranty ();
@@ -314,23 +311,23 @@ Please check your configuration file and permissions\n\n"));
   time_str_appended = calloc (LEN_TIME_STR_APPENDED, 1);
   get_time_string (time_str_appended, LEN_TIME_STR_APPENDED, "_%H%M%S-%y%m%d");
 
-  if (want_orphan_chk)
+  if (cli_user_options.want_orphan_chk)
   {
     waste_curr = waste_head;
     orphan_maint(waste_curr);
     return 0;
   }
 
-  if (want_selection_menu)
+  if (cli_user_options.want_selection_menu)
   {
     waste_curr = waste_head;
     return restore_select (waste_curr);
   }
 
   /* FIXME:
-   * want_undo_rmw() should return a value
+   * cli_user_options.want_undo_rmw() should return a value
    */
-  if (want_undo)
+  if (cli_user_options.want_undo)
   {
     waste_curr = waste_head;
     undo_last_rmw (waste_curr);
@@ -503,6 +500,9 @@ rmw_option_init (rmw_options *options)
   options->want_restore = false;
   options->want_purge = false;
   options->want_empty_trash = false;
+  options->want_orphan_chk = false;
+  options->want_selection_menu = false;
+  options->want_undo = false;
 }
 
 /*!
@@ -623,7 +623,7 @@ is_time_to_purge (void)
  *
  * @param[out] removals linked lists of files that have been succesfully rmw'ed
  * @param[in] file file that has been successfully rmw'ed
- * @see want_undo_rmw
+ * @see cli_user_options.want_undo_rmw
  * @return pointer to node in @ref st_removed type struct
  */
 st_removed*
@@ -670,7 +670,7 @@ dispose_removed (st_removed *node)
  * @param[in] removals the linked list of files that were rmw'ed
  * @param[in] removals_head the first node in removals
  * @return void
- * @see want_undo_rmw
+ * @see cli_user_options.want_undo_rmw
  * @see add_removal
  */
 void

--- a/src/rmw.c
+++ b/src/rmw.c
@@ -52,14 +52,9 @@
  *
  */
 
-/*! list waste folder option */
-bool list;
-
 /*! The users HOME directory */
 char *HOMEDIR;
 
-/*! Alternate configuration file given at the command line with -c */
-const char *alt_config = NULL;
 
 /*!
  * Formatted time string indicating the current time;
@@ -73,7 +68,6 @@ char *time_str_appended;
 int purge_after = 0;
 
 /*! Set from the command line and optionally from the user's config file */
-ushort force = 0;
 bool force_required = 0;
 
 /*
@@ -148,10 +142,10 @@ main (const int argc, char* const argv[])
       translate_config ();
       exit (0);
     case 'c':
-      alt_config = optarg;
+      cli_user_options.alt_config = optarg;
       break;
     case 'l':
-      list = 1;
+      cli_user_options.list = true;
       break;
     case 'g':
       cli_user_options.want_purge = true;
@@ -181,7 +175,7 @@ main (const int argc, char* const argv[])
       printf (_("-r / --recurse: not implemented\n"));
       break;
     case 'f':
-      force++;
+      cli_user_options.force++;
       break;
     case 'e':
       cli_user_options.want_empty_trash = true;
@@ -254,11 +248,11 @@ Please check your configuration file and permissions\n\n"));
   created_data_dir = (created_data_dir == MAKE_DIR_SUCCESS) ? FIRST_RUN : 0;
 
   st_waste *waste_head;
-  waste_head = get_config_data ();
+  waste_head = get_config_data (&cli_user_options);
 
   st_waste *waste_curr = waste_head;
 
-  if (list)
+  if (cli_user_options.list)
   {
     while (waste_curr != NULL)
     {
@@ -301,7 +295,7 @@ Please check your configuration file and permissions\n\n"));
 
   if (cli_user_options.want_purge || is_time_to_purge())
   {
-    if (!force_required || force)
+    if (!force_required || cli_user_options.force)
       purge (waste_curr, &cli_user_options);
     else
       printf (_("purge has been skipped: use -f or --force\n"));
@@ -503,6 +497,10 @@ rmw_option_init (rmw_options *options)
   options->want_orphan_chk = false;
   options->want_selection_menu = false;
   options->want_undo = false;
+  options->force = 0;
+  options->list = false;
+  options->alt_config = NULL;
+
 }
 
 /*!

--- a/src/rmw.h
+++ b/src/rmw.h
@@ -101,6 +101,9 @@ struct rmw_options
   bool want_restore;
   bool want_purge;
   bool want_empty_trash;
+  bool want_orphan_chk;
+  bool want_selection_menu;
+  bool want_undo;
 };
 
 typedef struct st_waste st_waste;

--- a/src/rmw.h
+++ b/src/rmw.h
@@ -105,9 +105,9 @@ struct rmw_options
   bool want_selection_menu;
   bool want_undo;
   ushort force;
-  /*! Alternate configuration file given at the command line with -c */
   /*! list waste folder option */
   bool list;
+  /*! Alternate configuration file given at the command line with -c */
   const char *alt_config;
 };
 

--- a/src/rmw.h
+++ b/src/rmw.h
@@ -104,6 +104,11 @@ struct rmw_options
   bool want_orphan_chk;
   bool want_selection_menu;
   bool want_undo;
+  ushort force;
+  /*! Alternate configuration file given at the command line with -c */
+  /*! list waste folder option */
+  bool list;
+  const char *alt_config;
 };
 
 typedef struct st_waste st_waste;


### PR DESCRIPTION
Make the code more uniform by moving user option flags into the cli_user_options struct. (@andy5995 's suggestion)