### PR TITLE
fix some coverity warnings

### DIFF
--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -301,13 +301,10 @@ parse_line_waste (st_waste * waste_curr, const char * line_from_config,
    * checking return values is good practice so we'll do it.
    */
   struct stat st;
-  if (lstat (waste_curr->parent, &st) == 0)
+  if (!lstat (waste_curr->parent, &st))
     waste_curr->dev_num = st.st_dev;
   else
-  {
-    print_msg_warn ();
-    perror ("lstat()");
-  }
+    msg_err_lstat(__func__, __LINE__);
 
   return waste_curr;
 
@@ -359,6 +356,7 @@ realize_config_file (char *config_file, const rmw_options * cli_user_options)
   }
 
   char tmp_config_file[MP];
+  bufchk (config_file, MP);
   strcpy (tmp_config_file, config_file);
 
   bufchk ("/rmwrc", MP - strlen (SYSCONFDIR));

--- a/src/messages_rmw.c
+++ b/src/messages_rmw.c
@@ -43,7 +43,8 @@ static const char *ERR_STRING[] = {
   "ERR_FGETS",
   "ERR_TRASHINFO_FORMAT",
   "FILE_NOT_FOUND",
-  "FIRST_RUN"
+  "FIRST_RUN",
+  "ERR_LSTAT"
 };
 
 void print_msg_error (void)
@@ -226,4 +227,15 @@ msg_err_buffer_overrun (const char *func, const int line)
   fputs ("buffer overrun (segmentation fault) prevented.\n", stderr);
   fputs ("If you think this may be a bug, please report it to the rmw developers.\n", stderr);
 }
+
+void
+msg_err_lstat (const char *func, const int LINE)
+{
+  print_msg_error();
+  perror ("lstat()");
+  fprintf (stderr, "%s - %d\n", func, LINE);
+  exit (ERR_LSTAT);
+}
+
+
 

--- a/src/messages_rmw.h
+++ b/src/messages_rmw.h
@@ -62,3 +62,6 @@ void msg_err_fatal_fprintf (const char *func);
 
 void
 msg_err_buffer_overrun (const char *func, const int line);
+
+void
+msg_err_lstat (const char *func, const int LINE);

--- a/src/purging_rmw.c
+++ b/src/purging_rmw.c
@@ -78,13 +78,15 @@ rmdir_recursive (char *path, short unsigned level, const rmw_options * cli_user_
 
     strcat (dir_path, entry->d_name);
 
-    lstat (dir_path, &st);
+    if (lstat (dir_path, &st))
+      msg_err_lstat (__func__, __LINE__);
     if (cli_user_options->force == 2 && ~st.st_mode & S_IWUSR)
     {
       if (!chmod (dir_path, 00700))
       {
         /* Now that the mode has changed, lstat must be run again */
-        lstat (dir_path, &st);
+        if (lstat (dir_path, &st))
+          msg_err_lstat (__func__, __LINE__);
       }
       else
       {
@@ -342,7 +344,8 @@ purge (const st_waste * waste_curr, const rmw_options * cli_user_options)
         truncate_str (temp, strlen (DOT_TRASHINFO));    /* acquire the basename */
 
         strcat (purgeFile, temp);       /* path to file in <WASTE>/files */
-        lstat (purgeFile, &st);
+        if (lstat (purgeFile, &st))
+          msg_err_lstat (__func__, __LINE__);
 
         if (S_ISDIR (st.st_mode))
         {

--- a/src/restore_rmw.c
+++ b/src/restore_rmw.c
@@ -337,7 +337,8 @@ restore_select (st_waste *waste_curr)
       bufchk (full_path, MP);
 
       struct stat st;
-      lstat (full_path, &st);
+      if (lstat (full_path, &st))
+        msg_err_lstat (__func__, __LINE__);
       char *hr_size = human_readable_size (st.st_size);
 
       /*

--- a/src/rmw.h
+++ b/src/rmw.h
@@ -203,7 +203,8 @@ enum {
   ERR_FGETS,
   ERR_TRASHINFO_FORMAT,
   FILE_NOT_FOUND,
-  FIRST_RUN
+  FIRST_RUN,
+  ERR_LSTAT
 };
 
 /* function prototypes for rmw.c

--- a/src/trashinfo_rmw.c
+++ b/src/trashinfo_rmw.c
@@ -147,13 +147,14 @@ printf ("file->base_name = %s in %s line %d\n", file->base_name, __func__, __LIN
   if (file->is_duplicate)
   {
     extern const char *time_str_appended;
-    bufchk (time_str_appended, MP - strlen (final_info_dest));
-    strcat (final_info_dest, time_str_appended);
+    int req_len = multi_strlen (2, final_info_dest, time_str_appended);
+    bufchk_len (req_len, MP, __func__, __LINE__);
+    strncat (final_info_dest, time_str_appended, strlen (final_info_dest));
   }
 
-  strcat (final_info_dest, DOT_TRASHINFO);
-
-  bufchk (final_info_dest, MP);
+  req_len = multi_strlen (2, final_info_dest, DOT_TRASHINFO);
+  bufchk_len (req_len, MP, __func__, __LINE__);
+  strncat (final_info_dest, DOT_TRASHINFO, strlen (final_info_dest));
 
   FILE *fp = fopen (final_info_dest, "w");
   if (fp != NULL)

--- a/src/utils_rmw.c
+++ b/src/utils_rmw.c
@@ -46,6 +46,7 @@ make_dir (const char *dir)
     return 0;
 
   char temp_dir[MP];
+  bufchk (dir, MP);
   strcpy (temp_dir, dir);
 
   char *tokenPtr;


### PR DESCRIPTION
Addressed some coverity warnings, one of which was checking for the return value of lstat()

`make check` still passes all tests, but I noticed this in basic.sh.log

```
---
+ echo rmw should append a time_string to duplicate files...
rmw should append a time_string to duplicate files...
+ cd /home/andy/src/rmw-project/_build/test/tmp-home/tmp-files
+ touch 1
+ touch 2
+ touch 3
+ /home/andy/src/rmw-project/_build/src/rmw -c /home/andy/src/rmw-project/_build/../rmw/test/rmw.testrc 1 2 3
lstat: No such file or directory
lstat: Invalid argument
lstat: Invalid argument
3 files were removed to the waste folder
+ touch 1
+ touch 2
+ touch 3
+ /home/andy/src/rmw-project/_build/src/rmw -c /home/andy/src/rmw-project/_build/../rmw/test/rmw.testrc 1 2 3
lstat: No such file or directory
lstat: Invalid argument
lstat: Invalid argument
3 files were removed to the waste folder
```

So I'll take a closer look soon.