### PR TITLE
refactor join_paths()

### DIFF
--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -181,7 +181,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   }
 
   bufchk_len(strlen(node->value) + 1, LEN_MAX_PATH, __func__, __LINE__);
-  char tmp_waste_parent_folder[LEN_MAX_PATH];
+  path_char tmp_waste_parent_folder;
   trim_char('/', node->value);
   strcpy(tmp_waste_parent_folder, node->value);
   if (realize_str(tmp_waste_parent_folder, homedir, uid) != 0)
@@ -218,8 +218,6 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   waste_curr->removable = removable ? true : false;
 
   /* make the parent... */
-  waste_curr->parent = malloc(strlen(tmp_waste_parent_folder) + 1);
-  chk_malloc(waste_curr->parent, __func__, __LINE__);
   strcpy(waste_curr->parent, tmp_waste_parent_folder);
 
   /* and the files... */
@@ -257,7 +255,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   {
     waste_curr->dev_num = st.st_dev;
 
-    char tmp[LEN_MAX_PATH];
+    path_char tmp;
     strcpy(tmp, waste_curr->parent);
     char *media_root_ptr = rmw_dirname(tmp);
     waste_curr->media_root = malloc(strlen(media_root_ptr) + 1);

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -223,7 +223,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   strcpy(waste_curr->parent, tmp_waste_parent_folder);
 
   /* and the files... */
-  waste_curr->files = join_paths(waste_curr->parent, lit_files);
+  join_paths2(waste_curr->files, LEN_MAX_PATH, waste_curr->parent, lit_files);
   waste_curr->len_files = strlen(waste_curr->files);
 
   if (!exists(waste_curr->files))
@@ -237,7 +237,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
     }
   }
 
-  waste_curr->info = join_paths(waste_curr->parent, lit_info);
+  join_paths2(waste_curr->info, LEN_MAX_PATH, waste_curr->parent, lit_info);
   waste_curr->len_info = strlen(waste_curr->info);
 
   if (!exists(waste_curr->info))

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -221,7 +221,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   strcpy(waste_curr->parent, tmp_waste_parent_folder);
 
   /* and the files... */
-  join_paths2(waste_curr->files, LEN_MAX_PATH, waste_curr->parent, lit_files);
+  join_paths2(waste_curr->files, sizeof_memb(st_waste, files), waste_curr->parent, lit_files);
   waste_curr->len_files = strlen(waste_curr->files);
 
   if (!exists(waste_curr->files))
@@ -235,7 +235,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
     }
   }
 
-  join_paths2(waste_curr->info, LEN_MAX_PATH, waste_curr->parent, lit_info);
+  join_paths2(waste_curr->info, sizeof_memb(st_waste, info), waste_curr->parent, lit_info);
   waste_curr->len_info = strlen(waste_curr->info);
 
   if (!exists(waste_curr->info))

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -181,7 +181,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   }
 
   bufchk_len(strlen(node->value) + 1, LEN_MAX_PATH, __func__, __LINE__);
-  path_char tmp_waste_parent_folder;
+  path_string tmp_waste_parent_folder;
   trim_char('/', node->value);
   strcpy(tmp_waste_parent_folder, node->value);
   if (realize_str(tmp_waste_parent_folder, homedir, uid) != 0)
@@ -221,7 +221,8 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   strcpy(waste_curr->parent, tmp_waste_parent_folder);
 
   /* and the files... */
-  join_paths2(waste_curr->files, sizeof_memb(st_waste, files), waste_curr->parent, lit_files);
+  join_paths2(waste_curr->files, sizeof_memb(st_waste, files),
+              waste_curr->parent, lit_files);
   waste_curr->len_files = strlen(waste_curr->files);
 
   if (!exists(waste_curr->files))
@@ -235,7 +236,8 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
     }
   }
 
-  join_paths2(waste_curr->info, sizeof_memb(st_waste, info), waste_curr->parent, lit_info);
+  join_paths2(waste_curr->info, sizeof_memb(st_waste, info),
+              waste_curr->parent, lit_info);
   waste_curr->len_info = strlen(waste_curr->info);
 
   if (!exists(waste_curr->info))
@@ -255,7 +257,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
   {
     waste_curr->dev_num = st.st_dev;
 
-    path_char tmp;
+    path_string tmp;
     strcpy(tmp, waste_curr->parent);
     char *media_root_ptr = rmw_dirname(tmp);
     waste_curr->media_root = malloc(strlen(media_root_ptr) + 1);

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -113,6 +113,19 @@ strrepl(char *src, const char *str, char *repl)
   return dest;
 }
 
+static void
+init_waste_values(st_waste * x)
+{
+  *x->parent = '\0';
+  *x->info = '\0';
+  x->len_info = 0;
+  *x->files = '\0';
+  x->len_files = 0;
+  x->dev_num = 0;
+  x->removable = false;
+  x->media_root = NULL;
+  return;
+}
 
 // looks for '$HOME', '$UID', or '~' in a string and replace it with its
 // corresponding literal value
@@ -201,6 +214,7 @@ parse_line_waste(st_waste * waste_curr, st_canfigger_node * node,
 
   st_waste *temp_node = malloc(sizeof(st_waste));
   chk_malloc(temp_node, __func__, __LINE__);
+  init_waste_values(temp_node);
 
   if (waste_curr != NULL)
   {

--- a/src/globals.h
+++ b/src/globals.h
@@ -59,6 +59,12 @@ typedef char path_char[LEN_MAX_PATH];
 
 #define LEN_MAX_ESCAPED_PATH (PATH_MAX * 3 + 1)
 
+// Get the size of a struct member without creating an instance
+// of the struct
+// https://stackoverflow.com/a/3864612/6838037
+#define sizeof_memb(a,m) sizeof(((a*)0)->m)
+// Thanks wkl <https://stackoverflow.com/users/297696/wkl>
+
 #define EBUF 11
 
 extern int verbose;

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,6 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*! The LEN_MAX_PATH macro is used as a shortcut throughout the program. */
 #define LEN_MAX_PATH (PATH_MAX + 1)
+typedef char path_char[LEN_MAX_PATH];
 
 #define LEN_MAX_ESCAPED_PATH (PATH_MAX * 3 + 1)
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,7 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*! The LEN_MAX_PATH macro is used as a shortcut throughout the program. */
 #define LEN_MAX_PATH (PATH_MAX + 1)
-typedef char path_char[LEN_MAX_PATH];
+typedef char path_string[LEN_MAX_PATH];
 
 #define LEN_MAX_ESCAPED_PATH (PATH_MAX * 3 + 1)
 

--- a/src/main.c
+++ b/src/main.c
@@ -625,7 +625,8 @@ Please check your configuration file and permissions\
       msg_warn_restore(restore_errors += restore(argv[file_arg],
                                                  &st_time_var,
                                                  &cli_user_options,
-                                                 st_config_data.st_waste_folder_props_head));
+                                                 st_config_data.
+                                                 st_waste_folder_props_head));
 
     dispose_waste(st_config_data.st_waste_folder_props_head);
 

--- a/src/main.c
+++ b/src/main.c
@@ -220,12 +220,15 @@ damage of 5000 hp. You feel satisfied.\n"));
     struct stat st_orig;
     if (!lstat(st_target.orig, &st_orig))
     {
-      st_target.real_path = resolve_path(st_target.orig, st_target.base_name);
-      if (st_target.real_path == NULL)
+      char *pp = resolve_path(st_target.orig, st_target.base_name);
+      if (pp == NULL)
       {
         n_err++;
         continue;
       }
+      sn_check(snprintf(st_target.real_path, sizeof(path_string), "%s", pp),
+               sizeof st_target.real_path);
+      free(pp);
     }
     else
     {
@@ -251,10 +254,7 @@ damage of 5000 hp. You feel satisfied.\n"));
       waste_curr = waste_curr->next_node;
     }
     if (is_protected)
-    {
-      free(st_target.real_path);
       continue;
-    }
 
     /**
      * Make some variables -
@@ -305,7 +305,6 @@ damage of 5000 hp. You feel satisfied.\n"));
           if (cli_user_options->want_dry_run == false)
             if (!create_trashinfo(&st_target, waste_curr, st_time_var))
             {
-              free(st_target.real_path);
               confirmed_removals_list =
                 add_removal(confirmed_removals_list,
                             st_target.waste_dest_name);
@@ -626,8 +625,7 @@ Please check your configuration file and permissions\
       msg_warn_restore(restore_errors += restore(argv[file_arg],
                                                  &st_time_var,
                                                  &cli_user_options,
-                                                 st_config_data.
-                                                 st_waste_folder_props_head));
+                                                 st_config_data.st_waste_folder_props_head));
 
     dispose_waste(st_config_data.st_waste_folder_props_head);
 

--- a/src/purging_rmw.c
+++ b/src/purging_rmw.c
@@ -214,7 +214,7 @@ static char *
 get_pt_basename(const char *purge_target)
 {
   static char *pt_basename;
-  static char pt_tmp[LEN_MAX_PATH];
+  static path_char pt_tmp;
   strcpy(pt_tmp, purge_target);
   pt_basename = basename(pt_tmp);
   return pt_basename;
@@ -244,7 +244,7 @@ static void
 get_purge_target(char *purge_target, const char *tinfo_d_name,
                  const char *files_dir)
 {
-  char temp[LEN_MAX_PATH];
+  path_char temp;
   sn_check(snprintf(temp, sizeof temp, "%s", tinfo_d_name), sizeof temp);
   truncate_str(temp, len_trashinfo_ext);        /* acquire the (basename - trashinfo extension) */
   char *path = join_paths(files_dir, temp);
@@ -331,7 +331,7 @@ purge(st_config * st_config_data,
         || cli_user_options->want_empty_trash;
       if (want_purge || verbose >= 2)
       {
-        char purge_target[LEN_MAX_PATH];
+        path_char purge_target;
         get_purge_target(purge_target, st_trashinfo_dir_entry->d_name,
                          waste_curr->files);
         char *pt_basename = get_pt_basename(purge_target);
@@ -405,7 +405,7 @@ orphan_maint(st_waste * waste_head, st_time * st_time_var, int *orphan_ctr)
       /* destination if restored */
       st_file_properties.real_path =
         join_paths(waste_curr->parent, "orphans",
-                   st_file_properties.base_name, NULL);
+                   st_file_properties.base_name);
 
       if (!create_trashinfo(&st_file_properties, waste_curr, st_time_var))
       {

--- a/src/restore_rmw.c
+++ b/src/restore_rmw.c
@@ -96,8 +96,7 @@ restore(const char *src, st_time * st_time_var,
       return 1;
     }
 
-    path_char src_tinfo;
-    path_char tmp_str;
+    path_char src_tinfo, tmp_str;
     join_paths2(tmp_str, sizeof tmp_str, waste_parent, lit_info, src_basename);
     sn_check(snprintf(src_tinfo, LEN_MAX_PATH, "%s%s", tmp_str, trashinfo_ext), sizeof src_tinfo);
 

--- a/src/restore_rmw.c
+++ b/src/restore_rmw.c
@@ -96,9 +96,12 @@ restore(const char *src, st_time * st_time_var,
       return 1;
     }
 
-    path_char src_tinfo, tmp_str;
-    join_paths2(tmp_str, sizeof tmp_str, waste_parent, lit_info, src_basename);
-    sn_check(snprintf(src_tinfo, LEN_MAX_PATH, "%s%s", tmp_str, trashinfo_ext), sizeof src_tinfo);
+    path_string src_tinfo, tmp_str;
+    join_paths2(tmp_str, sizeof tmp_str, waste_parent, lit_info,
+                src_basename);
+    sn_check(snprintf
+             (src_tinfo, LEN_MAX_PATH, "%s%s", tmp_str, trashinfo_ext),
+             sizeof src_tinfo);
 
     char *_dest = parse_trashinfo_file(src_tinfo, path_key);
     if (_dest == NULL)
@@ -108,12 +111,12 @@ restore(const char *src, st_time * st_time_var,
      * being restored resides, get the dirname of that waste folder and prepend it
      * to dest (thereby making the entire path absolute for restoration.
      */
-    path_char dest;
+    path_string dest;
     strcpy(dest, _dest);
     if (*_dest != '/')
     {
       char *media_root = rmw_dirname(waste_parent);
-      path_char _tmp_str;
+      path_string _tmp_str;
       join_paths2(_tmp_str, sizeof _tmp_str, media_root, _dest);
       strcpy(dest, _tmp_str);
     }

--- a/src/restore_rmw.c
+++ b/src/restore_rmw.c
@@ -97,6 +97,8 @@ restore(const char *src, st_time * st_time_var,
     }
 
     path_string src_tinfo, tmp_str;
+    *src_tinfo = '\0';
+    *tmp_str = '\0';
     join_paths2(tmp_str, sizeof tmp_str, waste_parent, lit_info,
                 src_basename);
     sn_check(snprintf
@@ -117,6 +119,7 @@ restore(const char *src, st_time * st_time_var,
     {
       char *media_root = rmw_dirname(waste_parent);
       path_string _tmp_str;
+      *_tmp_str = '\0';
       join_paths2(_tmp_str, sizeof _tmp_str, media_root, _dest);
       strcpy(dest, _tmp_str);
     }

--- a/src/restore_rmw.c
+++ b/src/restore_rmw.c
@@ -96,12 +96,10 @@ restore(const char *src, st_time * st_time_var,
       return 1;
     }
 
-    char src_tinfo[LEN_MAX_PATH];
-    char *tmp_str = join_paths(waste_parent, lit_info, src_basename);
-    int r = snprintf(src_tinfo, LEN_MAX_PATH, "%s%s", tmp_str, trashinfo_ext);
-    free(tmp_str);
-    tmp_str = NULL;
-    sn_check(r, LEN_MAX_PATH);
+    path_char src_tinfo;
+    path_char tmp_str;
+    join_paths2(tmp_str, sizeof tmp_str, waste_parent, lit_info, src_basename);
+    sn_check(snprintf(src_tinfo, LEN_MAX_PATH, "%s%s", tmp_str, trashinfo_ext), sizeof src_tinfo);
 
     char *_dest = parse_trashinfo_file(src_tinfo, path_key);
     if (_dest == NULL)
@@ -111,14 +109,14 @@ restore(const char *src, st_time * st_time_var,
      * being restored resides, get the dirname of that waste folder and prepend it
      * to dest (thereby making the entire path absolute for restoration.
      */
-    char dest[LEN_MAX_PATH];
+    path_char dest;
     strcpy(dest, _dest);
     if (*_dest != '/')
     {
       char *media_root = rmw_dirname(waste_parent);
-      char *_tmp_str = join_paths(media_root, _dest);
+      path_char _tmp_str;
+      join_paths2(_tmp_str, sizeof _tmp_str, media_root, _dest);
       strcpy(dest, _tmp_str);
-      free(_tmp_str);
     }
     free(waste_parent);
     free(_dest);

--- a/src/strings_rmw.h
+++ b/src/strings_rmw.h
@@ -33,7 +33,7 @@ bufchk_len(const size_t len, const size_t boundary, const char *func,
 
 void
 real_sn_check(const size_t len, const size_t dest_boundary, const char *func,
-         const int line);
+              const int line);
 
 void trim_whitespace(char *str);
 

--- a/src/trashinfo_rmw.h
+++ b/src/trashinfo_rmw.h
@@ -39,15 +39,15 @@ typedef struct st_waste st_waste;
 struct st_waste
 {
   /** The parent directory, e.g. $HOME/.local/share/Trash */
-  path_char parent;
+  path_string parent;
 
   /*! The info directory (where .trashinfo files are written) will be appended to the parent directory */
-  path_char info;
+  path_string info;
   int len_info;
 
   /** Appended to the parent directory, where files are moved to when they are rmw'ed
    */
-  path_char files;
+  path_string files;
   int len_files;
 
   /** The device number of the filesystem on which the file resides. rmw does
@@ -86,7 +86,7 @@ typedef struct
   const char *orig;
 
   /** The absolute path to the file, stored later in a .trashinfo file */
-  char *real_path;
+  path_string real_path;
 
   /** The basename of the target file, and used for the basename of it's corresponding
    * .trashinfo file */

--- a/src/trashinfo_rmw.h
+++ b/src/trashinfo_rmw.h
@@ -42,12 +42,12 @@ struct st_waste
   char *parent;
 
   /*! The info directory (where .trashinfo files are written) will be appended to the parent directory */
-  char *info;
+  char info[LEN_MAX_PATH];
   int len_info;
 
   /** Appended to the parent directory, where files are moved to when they are rmw'ed
    */
-  char *files;
+  char files[LEN_MAX_PATH];
   int len_files;
 
   /** The device number of the filesystem on which the file resides. rmw does

--- a/src/trashinfo_rmw.h
+++ b/src/trashinfo_rmw.h
@@ -39,15 +39,15 @@ typedef struct st_waste st_waste;
 struct st_waste
 {
   /** The parent directory, e.g. $HOME/.local/share/Trash */
-  char *parent;
+  path_char parent;
 
   /*! The info directory (where .trashinfo files are written) will be appended to the parent directory */
-  char info[LEN_MAX_PATH];
+  path_char info;
   int len_info;
 
   /** Appended to the parent directory, where files are moved to when they are rmw'ed
    */
-  char files[LEN_MAX_PATH];
+  path_char files;
   int len_files;
 
   /** The device number of the filesystem on which the file resides. rmw does

--- a/src/utils_rmw.c
+++ b/src/utils_rmw.c
@@ -150,7 +150,6 @@ dispose_waste(st_waste * node)
   if (node != NULL)
   {
     dispose_waste(node->next_node);
-    free(node->parent);
     if (node->media_root != NULL)
       free(node->media_root);
     free(node);
@@ -589,7 +588,7 @@ test_make_size_human_readable(void)
 void
 test_join_paths(void)
 {
-  char path[LEN_MAX_PATH];
+  path_char path;
   join_paths2(path, sizeof path, "home", "foo//", "bar");
   assert(*path != '\0');
   assert(strcmp(path, "home/foo/bar") == 0);

--- a/src/utils_rmw.c
+++ b/src/utils_rmw.c
@@ -436,9 +436,17 @@ real_join_paths(const char *argv, ...)
 }
 
 void
-real_join_paths2(char *dest, ssize_t max_len, const char *argv, ...)
+real_join_paths2(char *dest, size_t max_len, const char *argv, ...)
 {
-  *dest = '\0';
+  //if (*dest != '\0')
+  //exit(EXIT_FAILURE);
+  if (max_len <= sizeof(char *))
+  {
+    fputs("Incoming message from join_paths2....\n\
+      max_len too small; did you pass the size of a pointer instead?\n", stderr);
+    exit(EXIT_FAILURE);
+  }
+
   va_list ap;
   char *str = (char *) argv;
   va_start(ap, argv);
@@ -450,7 +458,7 @@ real_join_paths2(char *dest, ssize_t max_len, const char *argv, ...)
     chk_malloc(dup_str, __func__, __LINE__);
     trim_char('/', dup_str);
     len = strlen(dest);
-    ssize_t boundary = max_len - len;
+    size_t boundary = max_len - len;
     sn_check(snprintf(dest + len, boundary, "%s/", dup_str), boundary);
     free(dup_str);
     str = va_arg(ap, char *);
@@ -589,14 +597,21 @@ void
 test_join_paths(void)
 {
   path_string path;
+  *path = '\0';
   join_paths2(path, sizeof path, "home", "foo//", "bar");
   assert(*path != '\0');
   assert(strcmp(path, "home/foo/bar") == 0);
 
+  *path = '\0';
   join_paths2(path, sizeof path, "/home/foo", "bar", "world/");
   assert(*path != '\0');
   assert(strcmp(path, "/home/foo/bar/world") == 0);
 
+  // path can be appended
+  //join_paths2(path, sizeof path, "hello", "backwards");
+  //assert(*path != '\0');
+  //fputs(path, stderr);
+  //assert(strcmp(path, "/home/foo/bar/world/hello/backwards") == 0);
   return;
 }
 

--- a/src/utils_rmw.c
+++ b/src/utils_rmw.c
@@ -588,7 +588,7 @@ test_make_size_human_readable(void)
 void
 test_join_paths(void)
 {
-  path_char path;
+  path_string path;
   join_paths2(path, sizeof path, "home", "foo//", "bar");
   assert(*path != '\0');
   assert(strcmp(path, "home/foo/bar") == 0);

--- a/src/utils_rmw.h
+++ b/src/utils_rmw.h
@@ -58,6 +58,6 @@ void trim_char(const int c, char *str);
 
 char *real_join_paths(const char *argv, ...);
 
-void real_join_paths2(char *dest, ssize_t max_len, const char *argv, ...);
+void real_join_paths2(char *dest, size_t max_len, const char *argv, ...);
 
 #endif

--- a/src/utils_rmw.h
+++ b/src/utils_rmw.h
@@ -26,7 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "trashinfo_rmw.h"
 
-#define join_paths(...) real_join_paths(__VA_ARGS__, NULL)
+#define join_paths(s, ...) real_join_paths(s, __VA_ARGS__, NULL)
+#define join_paths2(a, n, b, ...) real_join_paths2(a, n, b, __VA_ARGS__, NULL)
 
 #define LEN_MAX_HUMAN_READABLE_SIZE (sizeof "xxxx.y GiB")
 #define LEN_MAX_FILE_DETAILS (LEN_MAX_HUMAN_READABLE_SIZE + sizeof "[] (D)" - 1)
@@ -56,5 +57,7 @@ char *resolve_path(const char *file, const char *b);
 void trim_char(const int c, char *str);
 
 char *real_join_paths(const char *argv, ...);
+
+void real_join_paths2(char *dest, ssize_t max_len, const char *argv, ...);
 
 #endif


### PR DESCRIPTION
char array previously declared must be passed instead of using malloc and freeing later