### PR TITLE
add non-verbose status to purge action

### DIFF
--- a/src/purging_rmw.c
+++ b/src/purging_rmw.c
@@ -188,6 +188,9 @@ do_file_purge(char *purge_target, const rmw_options *cli_user_options,
       (*ctr)++;
       if (verbose)
         printf("-%s\n", pt_basename);
+      else
+        if ((*ctr % 50) == 0)
+          putchar('-');
     }
     else
       msg_err_remove(trashinfo_entry_realpath, __func__);
@@ -254,10 +257,11 @@ purge(st_config *st_config_data,
     printf(_("Purging all files in waste folders ...\n"));
   else
     printf(_
-           ("Purging files based on number of days in the waste folders (%u) ...\n"),
+           ("Purging files based on number of days in the waste folders (%u) "),
            st_config_data->expire_age);
 
   int ctr = 0;
+  int n_entries = 0;
 
   st_waste *waste_curr = st_config_data->st_waste_folder_props_head;
   while (waste_curr != NULL)
@@ -280,6 +284,13 @@ purge(st_config *st_config_data,
     {
       if (isdotdir(st_trashinfo_dir_entry->d_name))
         continue;
+
+      if (!verbose)
+      {
+        n_entries++;
+        if ((n_entries % 25) == 0)
+          putchar('*');
+      }
 
       char *tmp_str =
         join_paths(waste_curr->info, st_trashinfo_dir_entry->d_name);
@@ -326,6 +337,8 @@ purge(st_config *st_config_data,
     waste_curr = waste_curr->next_node;
   }
 
+  if (!verbose)
+    putchar('\n');
   printf(ngettext("%d item purged", "%d items purged", ctr), ctr);
   putchar('\n');
 

--- a/test/test_purging.sh
+++ b/test/test_purging.sh
@@ -167,9 +167,8 @@ create_temp_files
 RMW_FAKE_YEAR=True $RMW_TEST_CMD_STRING ${RMW_FAKE_HOME}/tmp-files/*
 output=$($RMW_TEST_CMD_STRING -g)
 echo $output
-test "${output}" = "
-Purging files based on number of days in the waste folders (90) ...
-3 items purged"
+cmp_substr "${output}" "3 items purged"
+cmp_substr "${output}" "Purging files based on number of days in the waste folders (90)"
 
 # filenames with parens
 # THIS TEST DOESN'T WORK.


### PR DESCRIPTION
This is how it looks with this patch so far:

```
[andy@prometheus tmp](master)$ touch {0..400}
[andy@prometheus tmp](master)$ RMW_FAKE_YEAR=true ../rmw *
RMW_FAKE_YEAR:true
401 items were removed to the waste folder
[andy@prometheus tmp](master)$ ../rmw -g

Purging files based on number of days in the waste folders (45) **-**-**-**-**-**-**-**-
401 items purged
```