### PR TITLE
Avoid 32-bit integer overflow after 2038

### DIFF
--- a/src/purging_rmw.c
+++ b/src/purging_rmw.c
@@ -61,7 +61,7 @@ is_time_to_purge(st_time *st_time_var, const char *file)
     trim_whitespace(time_prev);
     close_file(&fp, file, __func__);
 
-    if ((st_time_var->now - atoi(time_prev)) < SECONDS_IN_A_DAY)
+    if ((st_time_var->now - atoll(time_prev)) < SECONDS_IN_A_DAY)
       return false;
   }
 


### PR DESCRIPTION
after 2038-01-19, a 32-bit signed int is no more sufficient
to hold UNIX epoch timestamp values and will overflow to
minus 2 billion.

Fixes #439