### PR TITLE
Use strcpy instead of snprintf (fix #464)

### DIFF
--- a/src/messages_rmw.c
+++ b/src/messages_rmw.c
@@ -103,8 +103,9 @@ display_dot_trashinfo_error(const char *dti)
 void
 real_fatal_malloc(const char *func, const int line)
 {
+  int save_errno = errno;
   fprintf(stderr, "%s -- %s:L%d\n", strerror(errno), func, line);
-  exit(ENOMEM);
+  exit(save_errno);
 }
 
 

--- a/src/restore_rmw.h
+++ b/src/restore_rmw.h
@@ -18,11 +18,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <dirent.h>
-
 #if defined HAVE_NCURSESW_MENU_H
 #include <ncursesw/menu.h>
 #elif defined HAVE_NCURSES_MENU_H

--- a/src/strings_rmw.h
+++ b/src/strings_rmw.h
@@ -32,8 +32,8 @@ bufchk_len(const size_t len, const size_t boundary, const char *func,
            const int line);
 
 void
-real_sn_check(const size_t len, const size_t dest_boundary, const char *func,
-              const int line);
+real_sn_check(const ssize_t len, const ssize_t dest_boundary,
+              const char *func, const int line);
 
 void trim_whitespace(char *str);
 


### PR DESCRIPTION
And improve the tests a little bit

The snprintf man page states under CAVEATS:

The glibc implementation of the functions snprintf() and vsnprintf() conforms to the C99 standard, that is,  behaves
as described above, since glibc 2.1.  Until glibc 2.0.6, they would return -1 when the output was truncated.