### PR TITLE
fix: strip trailing slash from argument before path operations (close…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -289,6 +289,12 @@ remove_to_waste(const int argc,
     char tmp[PATH_MAX];
     sn_check(snprintf(tmp, sizeof(tmp), "%s", argv[file_arg]), sizeof(tmp));
 
+    trim_char('/', tmp);
+
+    /* keep a copy before basename() may clobber tmp */
+    char arg[PATH_MAX];
+    sn_check(snprintf(arg, sizeof(arg), "%s", tmp), sizeof(arg));
+
     // If basename() is given an empty string, it returns '.'
     st_target.base_name = basename(tmp);
     if (isdotdir(st_target.base_name))
@@ -309,7 +315,7 @@ damage of 5000 hp. You feel satisfied.\n"));
       continue;
     }
 
-    int p_state = check_pathname_state(argv[file_arg]);
+    int p_state = check_pathname_state(arg);
     if (p_state != EEXIST)
     {
       if (p_state == ENOENT)
@@ -319,10 +325,10 @@ damage of 5000 hp. You feel satisfied.\n"));
     }
 
     struct stat st_file_arg;
-    if (!lstat(argv[file_arg], &st_file_arg))
+    if (!lstat(arg, &st_file_arg))
     {
       st_target.dev_num = st_file_arg.st_dev;
-      st_target.real_path = resolve_path(argv[file_arg], st_target.base_name);
+      st_target.real_path = resolve_path(arg, st_target.base_name);
       if (st_target.real_path == NULL)
       {
         n_err++;
@@ -411,7 +417,7 @@ damage of 5000 hp. You feel satisfied.\n"));
         int r_result = 0;
         if (cli_user_options->want_dry_run == false)
         {
-          const char *src = argv[file_arg];
+          const char *src = arg;
           const char *dst = st_target.waste_dest_name;
 
           if (waste_curr->dev_num != st_target.dev_num)

--- a/src/utils.c
+++ b/src/utils.c
@@ -261,25 +261,23 @@ resolve_path(const char *file, const char *b)
 void
 trim_char(const int c, char *str)
 {
-  char *dup_str = str;
-  trim_whitespace(dup_str);
-  if (*dup_str == '\0')
+  char *p = str;
+  trim_whitespace(p);
+  if (*p == '\0')
     return;
 
-  while (*dup_str != '\0')
-    dup_str++;
+  while (*p != '\0')
+    p++;
 
-  dup_str--;
+  p--;
 
-  while (*dup_str == c)
+  while (*p == c)
   {
-    *dup_str = '\0';
-    if (dup_str == str)
+    *p = '\0';
+    if (p == str)
       return;
-    dup_str--;
+    p--;
   }
-
-  return;
 }
 
 

--- a/test/test_restore.sh
+++ b/test/test_restore.sh
@@ -146,12 +146,15 @@ if [ -n "$(command -v Xvfb)" ] && ! grep -q "DISABLE_CURSES" "$MESON_BUILD_ROOT/
   fi
 fi
 
-# Regression test: rmw file/ (trailing slash on regular file) must not move it
+# Regression test: rmw file/ (trailing slash on regular file) must move it
 echo "$SEPARATOR"
-echo "Trailing slash on regular file: must be rejected cleanly"
+echo "Trailing slash on regular file: must be moved and restorable"
 cd "${RMW_FAKE_HOME}"
 touch trailing_slash_file.txt
-${RMW_TEST_CMD_STRING} trailing_slash_file.txt/ || true
+${RMW_TEST_CMD_STRING} trailing_slash_file.txt/
+test ! -f "${RMW_FAKE_HOME}/trailing_slash_file.txt"
+test -f "${PRIMARY_WASTE_DIR}/files/trailing_slash_file.txt"
+${RMW_TEST_CMD_STRING} -u
 test -f "${RMW_FAKE_HOME}/trailing_slash_file.txt"
 
 # Regression test: rmw dir/ (trailing slash) then restore must not create dir/dir


### PR DESCRIPTION
…s #450)

A trailing slash on a symlink caused rename() to fail with ENOTDIR because
the kernel dereferenced the symlink. Strip any trailing slash from the argument early, before check_pathname_state, lstat, resolve_path, and rename, so "foo/" is treated identically to "foo".

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Fixes #450