### PR TITLE
tests: use strace to verify syscalls when available

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -89,7 +89,8 @@ jobs:
           gettext \
           libglib2.0-dev \
           meson \
-          ninja-build
+          ninja-build \
+          strace
 
     - if: ${{ contains(matrix.container, 'alpine') }}
       run: |
@@ -196,6 +197,7 @@ jobs:
           libglib2.0-dev \
           meson \
           ninja-build \
+          strace \
           xvfb
 
     - name: Configure with nls
@@ -226,6 +228,14 @@ jobs:
         meson setup builddir -Db_sanitize=none
         cd builddir
         meson test -v --setup=epochalypse --suite=rmw
+
+    - name: with sanitizers
+      run: |
+        cd builddir
+        meson setup --wipe \
+          -Db_sanitize=address,undefined \
+          -Db_lundef=false
+        meson test -v
 
     - name: with lto and FORTIFY
       run: |

--- a/test/COMMON
+++ b/test/COMMON
@@ -58,3 +58,25 @@ RMW_ALT_TEST_CMD_STRING="${BIN_DIR}/rmw -c ${ALT_CONFIG}"
 RMW_PURGE_DISABLED_CMD="${BIN_DIR}/rmw -c ${PURGE_DISABLED_CONFIG}"
 # shellcheck disable=SC2034
 SEPARATOR="\n\n--- "
+
+strace_check() {
+  # Usage: strace_check [-t trace_filter] pattern cmd [args...]
+  # Runs cmd under strace and asserts pattern appears in the syscall trace.
+  # -t overrides the default trace filter (%file); use "ioctl" for FICLONE checks.
+  # Skipped when $STRACE is unset or when ASAN is active (LSAN conflicts with ptrace).
+  _trace="%file"
+  if [ "$1" = "-t" ]; then
+    _trace="$2"
+    shift 2
+  fi
+  _pattern="$1"
+  shift
+  if [ -z "$STRACE" ] || [ -n "$ASAN_OPTIONS" ]; then
+    "$@"
+    return
+  fi
+  _strace_out=$(mktemp)
+  "$STRACE" -o "$_strace_out" -e "trace=$_trace" "$@"
+  grep -q "$_pattern" "$_strace_out"
+  rm -f "$_strace_out"
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -49,6 +49,11 @@ test_env = [
   'MESON_BUILD_ROOT=' + meson.project_build_root(),
 ]
 
+strace = find_program('strace', required: false)
+if strace.found()
+  test_env += ['STRACE=' + strace.full_path()]
+endif
+
 foreach s : scripts
   test(
     s,

--- a/test/test_basic.sh
+++ b/test/test_basic.sh
@@ -37,6 +37,7 @@ done
 cd "${RMW_FAKE_HOME}"/..
 
 printf "\n\n == rmw should be able to operate on multiple files\n"
+# shellcheck disable=SC2086
 strace_check "renam" $RMW_TEST_CMD_STRING --verbose "${RMW_FAKE_HOME}"/tmp-files/*
 
 test -f "${PRIMARY_WASTE_DIR}/files/1"
@@ -86,6 +87,7 @@ cmp_substr "$output" ".Waste/files/3_"
 echo "$SEPARATOR"
 echo "  == test undo/restore feature"
 
+# shellcheck disable=SC2086
 strace_check "renam" $RMW_TEST_CMD_STRING --verbose -u
 $RMW_TEST_CMD_STRING --verbose -z "$PRIMARY_WASTE_DIR"/files/1
 $RMW_TEST_CMD_STRING --verbose -z "$PRIMARY_WASTE_DIR"/files/2

--- a/test/test_basic.sh
+++ b/test/test_basic.sh
@@ -37,7 +37,7 @@ done
 cd "${RMW_FAKE_HOME}"/..
 
 printf "\n\n == rmw should be able to operate on multiple files\n"
-$RMW_TEST_CMD_STRING --verbose "${RMW_FAKE_HOME}"/tmp-files/*
+strace_check "renam" $RMW_TEST_CMD_STRING --verbose "${RMW_FAKE_HOME}"/tmp-files/*
 
 test -f "${PRIMARY_WASTE_DIR}/files/1"
 test -f "${PRIMARY_WASTE_DIR}/files/2"
@@ -86,7 +86,7 @@ cmp_substr "$output" ".Waste/files/3_"
 echo "$SEPARATOR"
 echo "  == test undo/restore feature"
 
-$RMW_TEST_CMD_STRING --verbose -u
+strace_check "renam" $RMW_TEST_CMD_STRING --verbose -u
 $RMW_TEST_CMD_STRING --verbose -z "$PRIMARY_WASTE_DIR"/files/1
 $RMW_TEST_CMD_STRING --verbose -z "$PRIMARY_WASTE_DIR"/files/2
 $RMW_TEST_CMD_STRING --verbose -z "$PRIMARY_WASTE_DIR"/files/3

--- a/test/test_btrfs_clone.sh
+++ b/test/test_btrfs_clone.sh
@@ -71,14 +71,14 @@ BTRFS_TEST_DIR="$BTRFS_MOUNTPOINT/test_dir"
 rm -rf "$BTRFS_TEST_DIR"
 mkdir "$BTRFS_TEST_DIR"
 touch "$BTRFS_TEST_DIR/bar"
-$BTRFS_RMW_CMD "$BTRFS_TEST_DIR"
+strace_check -t "ioctl" "FICLONE" $BTRFS_RMW_CMD "$BTRFS_TEST_DIR"
 test ! -d "$BTRFS_TEST_DIR"
 test -d "$BTRFS_WASTE_DIR/files/test_dir"
 test -f "$BTRFS_WASTE_DIR/files/test_dir/bar"
 test -f "$BTRFS_WASTE_DIR/info/test_dir.trashinfo"
 
 echo "== Test: restore the moved directory"
-$BTRFS_RMW_CMD -u
+strace_check -t "ioctl" "FICLONE" $BTRFS_RMW_CMD -u
 test -d "$BTRFS_TEST_DIR"
 test -f "$BTRFS_TEST_DIR/bar"
 test ! -f "$BTRFS_WASTE_DIR/info/test_dir.trashinfo"
@@ -159,7 +159,7 @@ echo "== Test: purge an expired file from btrfs waste"
 RMW_FAKE_YEAR=true $BTRFS_RMW_CMD foo
 test -f "$BTRFS_WASTE_DIR/files/foo"
 test -f "$BTRFS_WASTE_DIR/info/foo.trashinfo"
-$BTRFS_RMW_CMD -g
+strace_check "unlink" $BTRFS_RMW_CMD -g
 test ! -f "$BTRFS_WASTE_DIR/files/foo"
 test ! -f "$BTRFS_WASTE_DIR/info/foo.trashinfo"
 

--- a/test/test_btrfs_clone.sh
+++ b/test/test_btrfs_clone.sh
@@ -71,6 +71,7 @@ BTRFS_TEST_DIR="$BTRFS_MOUNTPOINT/test_dir"
 rm -rf "$BTRFS_TEST_DIR"
 mkdir "$BTRFS_TEST_DIR"
 touch "$BTRFS_TEST_DIR/bar"
+# shellcheck disable=SC2086
 strace_check -t "ioctl" "FICLONE" $BTRFS_RMW_CMD "$BTRFS_TEST_DIR"
 test ! -d "$BTRFS_TEST_DIR"
 test -d "$BTRFS_WASTE_DIR/files/test_dir"
@@ -78,6 +79,7 @@ test -f "$BTRFS_WASTE_DIR/files/test_dir/bar"
 test -f "$BTRFS_WASTE_DIR/info/test_dir.trashinfo"
 
 echo "== Test: restore the moved directory"
+# shellcheck disable=SC2086
 strace_check -t "ioctl" "FICLONE" $BTRFS_RMW_CMD -u
 test -d "$BTRFS_TEST_DIR"
 test -f "$BTRFS_TEST_DIR/bar"
@@ -159,6 +161,7 @@ echo "== Test: purge an expired file from btrfs waste"
 RMW_FAKE_YEAR=true $BTRFS_RMW_CMD foo
 test -f "$BTRFS_WASTE_DIR/files/foo"
 test -f "$BTRFS_WASTE_DIR/info/foo.trashinfo"
+# shellcheck disable=SC2086
 strace_check "unlink" $BTRFS_RMW_CMD -g
 test ! -f "$BTRFS_WASTE_DIR/files/foo"
 test ! -f "$BTRFS_WASTE_DIR/info/foo.trashinfo"

--- a/test/test_purging.sh
+++ b/test/test_purging.sh
@@ -127,6 +127,7 @@ echo
 echo
 echo " == The trashinfo records that these files were rmw'ed in 1999"
 echo " == So they will be purged now."
+# shellcheck disable=SC2086
 strace_check "unlink" $RMW_TEST_CMD_STRING --verbose --purge
 test ! -e "$PRIMARY_WASTE_DIR"/files/abc
 test ! -e "$PRIMARY_WASTE_DIR"/info/abc.trashinfo

--- a/test/test_purging.sh
+++ b/test/test_purging.sh
@@ -127,7 +127,7 @@ echo
 echo
 echo " == The trashinfo records that these files were rmw'ed in 1999"
 echo " == So they will be purged now."
-$RMW_TEST_CMD_STRING --verbose --purge
+strace_check "unlink" $RMW_TEST_CMD_STRING --verbose --purge
 test ! -e "$PRIMARY_WASTE_DIR"/files/abc
 test ! -e "$PRIMARY_WASTE_DIR"/info/abc.trashinfo
 test ! -e "$PRIMARY_WASTE_DIR"/files/123

--- a/test/test_restore.sh
+++ b/test/test_restore.sh
@@ -54,9 +54,9 @@ test "${output}" = "There are no items in the list - please check back later."
 
 echo "$SEPARATOR"
 echo "restore using wildcard pattern, but be in the trash directory"
-$RMW_TEST_CMD_STRING "${RMW_FAKE_HOME}"/somefiles/topdir -v
+strace_check "renam" $RMW_TEST_CMD_STRING "${RMW_FAKE_HOME}"/somefiles/topdir -v
 cd "$PRIMARY_WASTE_DIR"/files
-$RMW_TEST_CMD_STRING -z topd*
+strace_check "renam" $RMW_TEST_CMD_STRING -z topd*
 test -e "${RMW_FAKE_HOME}"/somefiles/topdir
 
 echo "$SEPARATOR"

--- a/test/test_restore.sh
+++ b/test/test_restore.sh
@@ -54,8 +54,10 @@ test "${output}" = "There are no items in the list - please check back later."
 
 echo "$SEPARATOR"
 echo "restore using wildcard pattern, but be in the trash directory"
+# shellcheck disable=SC2086
 strace_check "renam" $RMW_TEST_CMD_STRING "${RMW_FAKE_HOME}"/somefiles/topdir -v
 cd "$PRIMARY_WASTE_DIR"/files
+# shellcheck disable=SC2086
 strace_check "renam" $RMW_TEST_CMD_STRING -z topd*
 test -e "${RMW_FAKE_HOME}"/somefiles/topdir
 


### PR DESCRIPTION
Detect strace in the meson test setup and expose it as $STRACE in the test environment. Add a strace_check helper in COMMON that wraps a command with strace and asserts an expected syscall pattern appears in the trace. An optional -t flag overrides the default trace filter (%file), e.g. -t ioctl for FICLONE checks. Transparently falls back to a plain run when $STRACE is unset or when ASAN is active (LSAN conflicts with ptrace).

Wire strace_check into test_basic.sh (rename on move + undo), test_restore.sh (rename on move and wildcard restore), test_purging.sh (unlink on --purge), and test_btrfs_clone.sh (FICLONE ioctl on cross-subvolume move and restore, unlink on purge).

Add strace to apt installs in c-cpp.yml for the build and various jobs. Add a 'with sanitizers' step to the various job so ASAN/UBSAN coverage is explicit in CI (strace_check skips cleanly under sanitizers).