### PR TITLE
Prevent ncurses flashing when changing waste dirs

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -525,9 +525,9 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   }
   while (c != MENU_KEY_ESC && c != 'q' && c != 'x' && c != MENU_KEY_ENTER);
 
-  if (c != MENU_KEY_ENTER) {
+  if (c != MENU_KEY_ENTER)
     endwin();
-  }
+
   return restore_err_ctr;
 }
 #endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -482,9 +482,9 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
            && c != MENU_KEY_ESC && c != 'q' && c != 'x');
     // using 'q' to exit will be deprecated some day
 
+    endwin();
     if (c == MENU_KEY_ENTER)
     {
-      endwin();
       putchar('\n');
       ITEM **items;
       items = menu_items(my_menu);
@@ -525,9 +525,6 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   }
   while (c != MENU_KEY_ESC && c != 'q' && c != 'x' && c != MENU_KEY_ENTER);
 
-  if (c != MENU_KEY_ENTER) {
-    endwin();
-  }
   return restore_err_ctr;
 }
 #endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -482,9 +482,9 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
            && c != MENU_KEY_ESC && c != 'q' && c != 'x');
     // using 'q' to exit will be deprecated some day
 
-    endwin();
     if (c == MENU_KEY_ENTER)
     {
+      endwin();
       putchar('\n');
       ITEM **items;
       items = menu_items(my_menu);
@@ -525,6 +525,9 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   }
   while (c != MENU_KEY_ESC && c != 'q' && c != 'x' && c != MENU_KEY_ENTER);
 
+  if (c != MENU_KEY_ENTER) {
+    endwin();
+  }
   return restore_err_ctr;
 }
 #endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -330,6 +330,7 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   const int min_lines_required = start_line_bottom + 3;
   int c = 0;
   int restore_err_ctr = 0;
+  initscr();
   do
   {
     int n_choices = 0;
@@ -339,11 +340,11 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
     {
       /* we don't want errno to be changed because it's used in msg_error_open_dir()
        * but afaik, endwin() doesn't change errno */
+      endwin();
       msg_err_open_dir(waste_curr->files, __func__, __LINE__);
       exit(errno);
     }
 
-    initscr();
     if (LINES < min_lines_required)
     {
       endwin();
@@ -502,8 +503,6 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
         }
       }
     }
-    if (c != MENU_KEY_ENTER)
-      endwin();
 
     // Some demo menu code at
     // https://github.com/ThomasDickey/ncurses-snapshots/blob/master/test/demo_menus.c
@@ -526,6 +525,9 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   }
   while (c != MENU_KEY_ESC && c != 'q' && c != 'x' && c != MENU_KEY_ENTER);
 
+  if (c != MENU_KEY_ENTER) {
+    endwin();
+  }
   return restore_err_ctr;
 }
 #endif


### PR DESCRIPTION
The repeated endscr()/initscr() calls when changing waste locations causes a brief flash as the alternate screen is swapped out and in. This change moves them outside the keypress loop to eliminate that.