### PR TITLE
Start `rmw -s` with the closest matching waste location

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -325,7 +325,9 @@ int
 restore_select(st_waste *waste_head, st_time *st_time_var,
                const rmw_options *cli_user_options)
 {
-  st_waste *waste_curr = waste_head;
+  st_waste *waste_curr = get_nearest_waste(waste_head);
+  if (waste_curr == NULL)
+    waste_curr = waste_head;
   const int start_line_bottom = 7;
   const int min_lines_required = start_line_bottom + 3;
   int c = 0;

--- a/src/restore.c
+++ b/src/restore.c
@@ -313,6 +313,52 @@ insertion_sort(ITEM **a, const int n)
 }
 
 
+/*
+ * Returns the waste node whose parent path best matches the current
+ * working directory, using longest common path-component prefix.
+ * Returns NULL if waste_head is NULL or no match is found.
+ */
+static st_waste *
+get_nearest_waste(st_waste *waste_head)
+{
+  char cwdbuf[PATH_MAX];
+
+  if (getcwd(cwdbuf, sizeof cwdbuf) == NULL)
+  {
+    perror("getcwd");
+    return NULL;
+  }
+
+  st_waste *best = NULL;
+  size_t best_len = 0;
+
+  for (st_waste * curr = waste_head; curr != NULL; curr = curr->next_node)
+  {
+    size_t i = 0;
+    size_t last_sep = 0;
+
+    while (curr->parent[i] && cwdbuf[i] && curr->parent[i] == cwdbuf[i])
+    {
+      if (cwdbuf[i] == '/')
+        last_sep = i;
+      i++;
+    }
+
+    /* ensure we matched on a full component boundary */
+    if (cwdbuf[i] == '/' || cwdbuf[i] == '\0')
+      last_sep = i;
+
+    if (last_sep > best_len)
+    {
+      best_len = last_sep;
+      best = curr;
+    }
+  }
+
+  return best;
+}
+
+
 /*!
  * Displays a list of files that can be restored, user can select multiple
  * files using a curses-bases interface.

--- a/src/utils.c
+++ b/src/utils.c
@@ -310,52 +310,6 @@ count_chars(const char c, const char *str)
 }
 
 
-/*
- * Returns the waste node whose parent path best matches the current
- * working directory, using longest common path-component prefix.
- * Returns NULL if waste_head is NULL or no match is found.
- */
-st_waste *
-get_nearest_waste(st_waste *waste_head)
-{
-  char cwdbuf[PATH_MAX];
-
-  if (getcwd(cwdbuf, sizeof cwdbuf) == NULL)
-  {
-    perror("getcwd");
-    return NULL;
-  }
-
-  st_waste *best = NULL;
-  size_t best_len = 0;
-
-  for (st_waste * curr = waste_head; curr != NULL; curr = curr->next_node)
-  {
-    size_t i = 0;
-    size_t last_sep = 0;
-
-    while (curr->parent[i] && cwdbuf[i] && curr->parent[i] == cwdbuf[i])
-    {
-      if (cwdbuf[i] == '/')
-        last_sep = i;
-      i++;
-    }
-
-    /* ensure we matched on a full component boundary */
-    if (cwdbuf[i] == '/' || cwdbuf[i] == '\0')
-      last_sep = i;
-
-    if (last_sep > best_len)
-    {
-      best_len = last_sep;
-      best = curr;
-    }
-  }
-
-  return best;
-}
-
-
 ///////////////////////////////////////////////////////////////////////
 #ifdef TEST_LIB
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -310,6 +310,50 @@ count_chars(const char c, const char *str)
 }
 
 
+/*
+ * Returns the waste node whose parent path best matches the current
+ * working directory, using longest common path-component prefix.
+ * Returns NULL if waste_head is NULL or no match is found.
+ */
+st_waste *
+get_nearest_waste(st_waste *waste_head)
+{
+  char cwdbuf[PATH_MAX];
+
+  if (getcwd(cwdbuf, sizeof cwdbuf) == NULL)
+  {
+    perror("getcwd");
+    return NULL;
+  }
+
+  st_waste *best = NULL;
+  size_t best_len = 0;
+
+  for (st_waste * curr = waste_head; curr != NULL; curr = curr->next_node)
+  {
+    size_t i = 0;
+    size_t last_sep = 0;
+
+    while (curr->parent[i] && cwdbuf[i] && curr->parent[i] == cwdbuf[i])
+    {
+      if (cwdbuf[i] == '/')
+        last_sep = i;
+      i++;
+    }
+
+    /* ensure we matched on a full component boundary */
+    if (cwdbuf[i] == '/' || cwdbuf[i] == '\0')
+      last_sep = i;
+
+    if (last_sep > best_len)
+    {
+      best_len = last_sep;
+      best = curr;
+    }
+  }
+
+  return best;
+}
 
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,6 +62,4 @@ bool is_dir_f(const char *pathname);
 
 int count_chars(const char c, const char *str);
 
-st_waste *get_nearest_waste(st_waste *waste_head);
-
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,5 +62,6 @@ bool is_dir_f(const char *pathname);
 
 int count_chars(const char c, const char *str);
 
+st_waste *get_nearest_waste(st_waste *waste_head);
 
 #endif


### PR DESCRIPTION
Start the restore command at the nearest Trash location. We compare the current working directory against waste locations for the longest prefix match. If no match is found the current behavior applies: the first configured directory is used. Fixes #532.