### PR TITLE
Automatic support for filesystem $topdir/.Trash folders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,11 +165,13 @@ Each waste folder has two subdirectories following the FreeDesktop spec:
 
 C unit tests (`test_strings_rmw`, `test_utils`, `test_restore`) are compiled with `-DTEST_LIB`, which exposes internal functions via `#ifdef TEST_LIB` guards in the source files. `test_topdir_trash` (iss-525) includes its translation unit directly to reach static functions.
 
-Shell integration tests run against the built `rmw` binary using `RMW_FAKE_HOME` (set to `_build-debug/test/rmw-tests-home/`) to avoid touching the real home directory:
+Shell integration tests run against the built `rmw` binary using `RMW_FAKE_HOME` (set to `_build-debug/test/rmw-tests-home/`) to avoid touching the real home directory. `RMW_FAKE_HOME` also suppresses topdir discovery (it would scan the host's real mounts); a test that needs discovery sets `RMW_CHECK_DISCOVERY` to re-enable it against mounts the test controls.
 
 - `test_basic.sh`, `test_purging.sh`, `test_restore.sh` — core flows, no special requirements
+- `test_waste_negation.sh` (iss-525) — `!WASTE` is skipped for removals but listed/restored/purged
 - `test_media_root.sh` — needs `/tmp` to be a top-level mount on its own device; skips otherwise
 - `test_exdev_fallback.sh` (iss-525) — bind-mount EXDEV regression test; builds a 2 MiB tmpfs ramdisk with a bind mount inside it. Needs passwordless `sudo`; SKIPs otherwise
+- `test_discovery.sh` (iss-525) — discovery's excluded-fs rule, run inside an unprivileged mount namespace (`unshare --mount --map-root-user`, no sudo); SKIPs if unprivileged userns is unavailable
 - `test_btrfs_clone.sh`, `test_bcachefs.sh` — reflink tests against prebuilt loopback images (`test/*.img`, not in the repo; CI downloads them, sha256sums are committed). Need the image + passwordless `sudo`; SKIP otherwise
 
 To test Year 2038 (epochalypse) behavior when `faketime` is installed:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ Shell integration tests run against the built `rmw` binary using `RMW_FAKE_HOME`
 - `test_media_root.sh` — needs `/tmp` to be a top-level mount on its own device; skips otherwise
 - `test_exdev_fallback.sh` (iss-525) — bind-mount EXDEV regression test; builds a 2 MiB tmpfs ramdisk with a bind mount inside it. Needs passwordless `sudo`; SKIPs otherwise
 - `test_discovery.sh` (iss-525) — discovery's excluded-fs rule, run inside an unprivileged mount namespace (`unshare --mount --map-root-user`, no sudo); SKIPs if unprivileged userns is unavailable
+- `test_discovery_loopback.sh` (iss-525) — discovery of an eligible fs on its own device (candidate listing + fresh-trash auto-create); generates an ext4 loop image at run time. Needs passwordless `sudo` + `mkfs.ext4`; SKIPs otherwise
 - `test_btrfs_clone.sh`, `test_bcachefs.sh` — reflink tests against prebuilt loopback images (`test/*.img`, not in the repo; CI downloads them, sha256sums are committed). Need the image + passwordless `sudo`; SKIP otherwise
 
 To test Year 2038 (epochalypse) behavior when `faketime` is installed:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ C unit tests (`test_strings_rmw`, `test_utils`, `test_restore`) are compiled wit
 Shell integration tests run against the built `rmw` binary using `RMW_FAKE_HOME` (set to `_build-debug/test/rmw-tests-home/`) to avoid touching the real home directory. `RMW_FAKE_HOME` also suppresses topdir discovery (it would scan the host's real mounts); a test that needs discovery sets `RMW_CHECK_DISCOVERY` to re-enable it against mounts the test controls.
 
 - `test_basic.sh`, `test_purging.sh`, `test_restore.sh` — core flows, no special requirements
-- `test_waste_negation.sh` (iss-525) — `!WASTE` is skipped for removals but listed/restored/purged
+- `test_waste_negation.sh` (iss-525) — the `no-add` WASTE attribute is skipped for removals but listed/restored/purged
 - `test_media_root.sh` — needs `/tmp` to be a top-level mount on its own device; skips otherwise
 - `test_exdev_fallback.sh` (iss-525) — bind-mount EXDEV regression test; builds a 2 MiB tmpfs ramdisk with a bind mount inside it. Needs passwordless `sudo`; SKIPs otherwise
 - `test_discovery.sh` (iss-525) — discovery's excluded-fs rule, run inside an unprivileged mount namespace (`unshare --mount --map-root-user`, no sudo); SKIPs if unprivileged userns is unavailable

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 rmw (in-progress):
   * restore: 'rmw -s' now opens at the waste folder closest to the current
     directory (longest path match) instead of the first one listed (#532)
+  * config: add "!WASTE" — the folder never receives removed files but is
+    still listed, restored from, and purged
   * purge: print a progress dot per 100 trashinfo files checked for
     expiration; show a leading dot immediately so feedback is visible
     on the first iteration

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,8 @@
 rmw (in-progress):
   * restore: 'rmw -s' now opens at the waste folder closest to the current
     directory (longest path match) instead of the first one listed (#532)
-  * config: add "!WASTE" — the folder never receives removed files but is
-    still listed, restored from, and purged
+  * config: add the "no-add" WASTE attribute — the folder never receives
+    removed files but is still listed, restored from, and purged
   * purge: print a progress dot per 100 trashinfo files checked for
     expiration; show a leading dot immediately so feedback is visible
     on the first iteration

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 rmw (in-progress):
   * restore: 'rmw -s' now opens at the waste folder closest to the current
     directory (longest path match) instead of the first one listed (#532)
+  * config: configuring waste folders is now optional. With nothing
+    configured, rmw moves each file to the trash on the file's own
+    filesystem — the desktop trash (~/.local/share/Trash) for files on
+    your home filesystem, and a trash folder on the filesystem itself
+    for files elsewhere, such as on a removable drive
   * config: add the "no-add" WASTE attribute — the folder never receives
     removed files but is still listed, restored from, and purged
   * purge: print a progress dot per 100 trashinfo files checked for

--- a/man/rmw.1
+++ b/man/rmw.1
@@ -33,7 +33,11 @@ show help for command line options
 use an alternate configuration
 .TP
 \fB\-l\fR, \fB\-\-list\fR
-list waste directories
+list waste directories, one path per line
+.IP
+Add \fB\-v\fR to also show each folder's attributes (such as "no-add")
+and a list of candidate trash locations that rmw would create on other
+file systems when needed.
 .TP
 \fB\-g[N_DAYS]\fR, \fB\-\-purge\fR[=\fI\,N_DAYS\/\fR]
 purge expired files;
@@ -140,6 +144,12 @@ Two WASTE folders cannot be specified on the same line.
 WASTE=/mnt/flash/.Trash-$UID, removable
 When using the removable attribute, you must also manually create the directory
 .TP
+WASTE = /path, no-add
+The "no-add" attribute tells rmw to never move files into this folder.
+rmw still lists it, restores files from it, and purges old files in it.
+This is useful for a folder you want to empty over time but no longer add
+to. You can combine attributes, for example "removable, no-add".
+.TP
 expire_age = 45
 rmw will permanently delete files that have been in the waste (or
 trash) for more than 45 days.
@@ -163,10 +173,19 @@ text file that stores the time of the last purge
 .I $HOME/.local/share/rmw/mrl
 text file containing a list of items that were last rmw'ed
 .SH NOTES
-rmw will not move items from one file system to another. If you try to rmw a
-file but don't have a waste directory defined in your configuration file that
-matches the file system on which it resides, rmw will refuse to do anything
-with it.
+rmw does not move items from one file system to another. When you rmw a
+file, it looks for a waste directory on the same file system. It checks
+the waste directories in your configuration file first. If none match, it
+looks for a trash directory at the top of that file system, as described
+by the FreeDesktop.org Trash specification (for example,
+"/mnt/disk/.Trash-1000"). If one already exists, rmw uses it; if not, rmw
+creates one.
+.PP
+rmw does not create a trash directory on file systems that are not meant
+to hold one, such as temporary (tmpfs) or network file systems. On those,
+if no configured waste directory matches, rmw refuses to remove the file,
+the same way desktop file managers do. A trash directory that already
+exists on such a file system is still used.
 .SS DESKTOP INTEGRATION
 Items will be moved to a waste basket in the same manner as when using
 the "move to trash" option from your desktop GUI. They will be

--- a/man/rmw.1
+++ b/man/rmw.1
@@ -138,8 +138,19 @@ Restores files that were last rmw'ed
 \fB\-m\fR, \fB\-\-most\-recent\-list\fR
 list most recently rmw'ed files
 .SH CONFIGURATION
-Each WASTE folder must be on its own line in the configuration file.
-Two WASTE folders cannot be specified on the same line.
+Configuration is optional. With no configured WASTE folder, rmw moves each
+file to the trash on the file's own filesystem: files on the home filesystem
+go to the FreeDesktop home trash (~/.local/share/Trash, the same trash your
+desktop uses), and files on other filesystems go to a trash at the top of
+that filesystem. These are created when first needed.
+.PP
+Add WASTE lines only for special cases, such as keeping rmw's files separate
+from the desktop trash (uncomment the
+.B WASTE = $HOME/.local/share/Waste
+line in the generated config), a folder on removable media, or a
+.B no-add
+folder. Each WASTE folder must be on its own line; two WASTE folders cannot
+be specified on the same line.
 .TP
 WASTE=/mnt/flash/.Trash-$UID, removable
 When using the removable attribute, you must also manually create the directory
@@ -176,45 +187,40 @@ text file containing a list of items that were last rmw'ed
 rmw does not move items from one file system to another. When you rmw a
 file, it looks for a waste directory on the same file system. It checks
 the waste directories in your configuration file first. If none match, it
-looks for a trash directory at the top of that file system, as described
-by the FreeDesktop.org Trash specification (for example,
-"/mnt/disk/.Trash-1000"). If one already exists, rmw uses it; if not, rmw
-creates one.
+uses the trash for that file system, as described by the FreeDesktop.org
+Trash specification: the home trash (~/.local/share/Trash) for files on the
+home file system, or a trash at the top of the file system (for example,
+"/mnt/disk/.Trash-1000") for other file systems. If one already exists, rmw
+uses it; if not, rmw creates it.
 .PP
 rmw does not create a trash directory on file systems that are not meant
 to hold one, such as temporary (tmpfs) or network file systems. On those,
 if no configured waste directory matches, rmw refuses to remove the file,
 the same way desktop file managers do. A trash directory that already
 exists on such a file system is still used.
+.PP
+Because the default home trash is the same one your desktop uses, enabling
+purging (an
+.B expire_age
+greater than 0) lets rmw permanently delete old items that your file manager
+placed in the trash too, not only items removed with rmw. Purging is off by
+default.
 .SS DESKTOP INTEGRATION
-Items will be moved to a waste basket in the same manner as when using
-the "move to trash" option from your desktop GUI. They will be
-separated from your desktop trash by default; or if you wish for them
-to share the same "trash" directory, uncomment the line (in your config
-file):
-
-(Note that this does not apply to MacOS; while rmw is yet unable to
-integrate with the desktop trash directory, you'll still be able to use
-the default Waste directory.)
-
-.RS
-WASTE = $HOME/.local/share/Trash
-.RE
-
-then comment out the line
+Items are moved to the trash in the same manner as the "move to trash"
+option in your desktop file manager. By default rmw uses the same trash
+your desktop uses (the FreeDesktop home trash, ~/.local/share/Trash), so an
+item removed with rmw appears in your desktop trash and can be restored from
+either one.
+.PP
+To keep rmw's files separate from the desktop trash instead, uncomment this
+line in your configuration file:
 
 .RS
 WASTE = $HOME/.local/share/Waste
 .RE
 
-You can reverse which directories are enabled at any time if you ever
-change your mind. If both directories are on the same filesystem, rmw will
-use the directory listed first in your config file.
-
-It can be beneficial to have them both uncommented. If your desktop
-trash directory (~/.local/share/Trash) is listed after the rmw default
-(~/.local/share/Waste) and uncommented, rmw will place newly rmw'ed
-items into the default, and it will purge expired files from both.
+(On macOS rmw does not integrate with the system trash; the default
+~/.local/share/Trash is used.)
 
 When rmw'ing an item, if a file or directory with the same name already
 exists in the waste (or trash) directory, it will not be overwritten;

--- a/meson.build
+++ b/meson.build
@@ -72,8 +72,8 @@ canfigger_dep = dependency(
   default_options: 'default_library=static',
 )
 
-glib_dep = dependency('glib-2.0', version: '>=2.50')
-gio_dep  = dependency('gio-2.0',  version: '>=2.50')
+glib_dep = dependency('glib-2.0', version: '>=2.52')
+gio_dep  = dependency('gio-2.0',  version: '>=2.52')
 
 subdir('src')
 

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ canfigger_dep = dependency(
 )
 
 glib_dep = dependency('glib-2.0', version: '>=2.52')
-gio_dep  = dependency('gio-2.0',  version: '>=2.52')
+gio_dep = dependency('gio-2.0', version: '>=2.52')
 
 subdir('src')
 

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <unistd.h>
+#include <gio/gunixmounts.h>
 
 #include "ficlone.h"
 #include "config_rmw.h"
@@ -280,39 +281,33 @@ parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
   waste_curr->is_ficlone_fs = is_ficlone_fs(waste_curr->parent);
 
   // get device number to use later for rename
-  struct stat st, mp_st;
+  struct stat st;
   if (!lstat(waste_curr->parent, &st))
-  {
     waste_curr->dev_num = st.st_dev;
-
-    // printf("actual: %ld |major: %d | minor: %d\n", st.st_dev, major(st.st_dev), minor(st.st_dev));
-    gchar *media_root_ptr = g_path_get_dirname(waste_curr->parent);
-    if (!media_root_ptr)
-    {
-      fputs("Error getting media root pointer.\n", stderr);
-      exit(EXIT_FAILURE);
-    }
-
-    if (!(waste_curr->media_root = malloc(strlen(media_root_ptr) + 1)))
-      fatal_malloc();
-    strcpy(waste_curr->media_root, media_root_ptr);
-    g_free(media_root_ptr);
-
-    gchar *media_root_parent = g_path_get_dirname(waste_curr->media_root);
-    if (!lstat(media_root_parent, &mp_st))
-    {
-      if (mp_st.st_dev == waste_curr->dev_num)
-      {
-        free(waste_curr->media_root);
-        waste_curr->media_root = NULL;
-      }
-    }
-    else
-      msg_err_lstat(waste_curr->parent, __func__, __LINE__);
-    g_free(media_root_parent);
-  }
   else
     msg_err_lstat(waste_curr->parent, __func__, __LINE__);
+
+  waste_curr->media_root = NULL;
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  GUnixMountEntry *entry = g_unix_mount_for(waste_curr->parent, NULL);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+  if (entry)
+  {
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    const char *mount_path = g_unix_mount_get_mount_path(entry);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+    gchar *parent_dir = g_path_get_dirname(waste_curr->parent);
+    if (strcmp(mount_path, parent_dir) == 0)
+    {
+      if (!(waste_curr->media_root = malloc(strlen(mount_path) + 1)))
+        fatal_malloc();
+      strcpy(waste_curr->media_root, mount_path);
+    }
+    g_free(parent_dir);
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    g_unix_mount_free(entry);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+  }
 
   return waste_curr;
 }

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -42,30 +42,26 @@ void
 print_config(FILE *restrict stream)
 {
   fputs(_("\
-# rmw default waste directory, separate from the desktop trash\n"), stream);
-  fputs(_("\
-# To use multiple waste folders, specify each on a separate line\n"), stream);
-  fputs("\
-WASTE = $HOME/.local/share/Waste\n", stream);
+# rmw works with no configuration. By default it moves each file to the\n\
+# trash on the file's own filesystem; for files on your home filesystem\n\
+# that is the FreeDesktop trash at $HOME/.local/share/Trash.\n\
+#\n\
+# Add WASTE lines below only for special cases. Each waste folder goes\n\
+# on its own line, and a folder can use the $UID variable.\n"), stream);
   fputs(_("\n\
-# The directory used by the FreeDesktop.org Trash spec\n\
-# Note to macOS users: moving files to 'Desktop' trash\n\
-# doesn't work yet\n"), stream);
+# Keep rmw's files separate from the desktop trash:\n"), stream);
   fputs("\
-# WASTE=$HOME/.local/share/Trash\n", stream);
-  fputs("\n", stream);
-  fputs(_("\
-# A folder can use the $UID variable.\n"), stream);
-  fputs(_("\
-# See the README or man page for details about using the 'removable' attribute\n"), stream);
+# WASTE = $HOME/.local/share/Waste\n", stream);
+  fputs(_("\n\
+# A folder on a removable device (you must create the directory yourself):\n"), stream);
   fputs("\
-# WASTE=/mnt/flash/.Trash-$UID, removable\n", stream);
+# WASTE = /mnt/flash/.Trash-$UID, removable\n", stream);
   fputs(_("\n\
 # The 'no-add' attribute means rmw never puts files in this folder when\n\
 # you remove them. rmw can still list, restore, and purge what is\n\
-# already inside it.\n"), stream);
+# already inside it:\n"), stream);
   fputs("\
-# WASTE = $HOME/.local/share/Trash, no-add\n", stream);
+# WASTE = /mnt/archive/.Trash-$UID, no-add\n", stream);
   fputs(_("\n\
 # How many days should items be allowed to stay in the waste\n\
 # directories before they are permanently deleted\n\
@@ -421,17 +417,10 @@ parse_config_file(const rmw_options *cli_user_options,
     canfigger_free_current_key_node_advance(&cfg_node);
   }
 
-  if (waste_curr == NULL)
-  {
-    printf(_("no usable WASTE folder could be found\n\
-Please check your configuration file and permissions\n\
-If you need further help, or to report a possible bug,\n\
-visit the rmw web site at\n"));
-    printf("  " PACKAGE_URL "\n");
-    printf("Unable to continue. Exiting...\n");
-    exit(EXIT_FAILURE);
-  }
-
+  /* An empty waste list is no longer fatal: configuring waste folders is
+     optional. When nothing is configured, remove_to_waste() falls back to
+     the spec trash for each file's filesystem (the home trash for home-
+     filesystem files), creating it on demand. */
   return;
 }
 

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -456,8 +456,10 @@ void
 show_folder_line(const char *folder, const bool is_r, const bool is_attached,
                  const bool no_deposit)
 {
-  /* mirror the config syntax: a leading '!' marks a no-deposit folder */
-  printf("%s%s", no_deposit ? "!" : "", folder);
+  /* mirror the config syntax: a leading '!' marks a no-deposit folder.
+   * Only under -v: plain -l stays a bare list of paths, fit for piping
+   * to du and friends. */
+  printf("%s%s", (no_deposit && verbose) ? "!" : "", folder);
   if (is_r && verbose)
   {
     /*

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -434,7 +434,8 @@ init_config_data(st_config *x)
   x->force_required = 0;
 
   // get the UID
-  sn_check(snprintf(x->uid, sizeof x->uid, "%d", getuid()), sizeof x->uid);
+  sn_check(snprintf(x->uid, sizeof x->uid, "%s", get_user_uid_str()),
+           sizeof x->uid);
 }
 
 void

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -49,7 +49,7 @@ print_config(FILE *restrict stream)
 WASTE = $HOME/.local/share/Waste\n", stream);
   fputs(_("\n\
 # The directory used by the FreeDesktop.org Trash spec\n\
-# Note to macOS and Windows users: moving files to 'Desktop' trash\n\
+# Note to macOS users: moving files to 'Desktop' trash\n\
 # doesn't work yet\n"), stream);
   fputs("\
 # WASTE=$HOME/.local/share/Trash\n", stream);
@@ -60,6 +60,11 @@ WASTE = $HOME/.local/share/Waste\n", stream);
 # See the README or man page for details about using the 'removable' attribute\n"), stream);
   fputs("\
 # WASTE=/mnt/flash/.Trash-$UID, removable\n", stream);
+  fputs(_("\n\
+# A folder marked with '!' never receives files when you remove them.\n\
+# rmw can still list, restore, and purge files that are already in it.\n"), stream);
+  fputs("\
+# !WASTE = $HOME/.local/share/Trash\n", stream);
   fputs(_("\n\
 # How many days should items be allowed to stay in the waste\n\
 # directories before they are permanently deleted\n\
@@ -172,7 +177,8 @@ realize_str(char *str, const char *homedir, const char *uid)
 static st_waste *
 parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
                  const rmw_options *cli_user_options,
-                 const char *homedir, const char *uid)
+                 const char *homedir, const char *uid,
+                 const bool no_deposit)
 {
   bool removable = 0;
   char *attr = NULL;
@@ -203,10 +209,13 @@ parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
 
   bool is_attached =
     (check_pathname_state(tmp_waste_parent_folder) == EEXIST);
-  if (removable && !is_attached)
+  /* A "!WASTE" folder that doesn't exist is skipped rather than created:
+   * it can never receive files, and purge exits on an unopenable info dir. */
+  if ((removable || no_deposit) && !is_attached)
   {
     if (cli_user_options->list)
-      show_folder_line(tmp_waste_parent_folder, removable, is_attached);
+      show_folder_line(tmp_waste_parent_folder, removable, is_attached,
+                       no_deposit);
 
     return NULL;
   }
@@ -229,6 +238,7 @@ parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
   waste_curr->next_node = NULL;
 
   waste_curr->removable = removable ? true : false;
+  waste_curr->no_deposit = no_deposit;
 
   /* make the parent... */
   waste_curr->parent = malloc(strlen(tmp_waste_parent_folder) + 1);
@@ -333,6 +343,7 @@ parse_config_file(const rmw_options *cli_user_options,
   {
     EXPIRE_AGE,
     WASTE,
+    WASTE_NEGATED,
     FORCE_REQUIRED,
     PURGE_AFTER,
     INVALID_OPTION
@@ -346,6 +357,7 @@ parse_config_file(const rmw_options *cli_user_options,
 
   struct opt st_opt[] = {
     {"WASTE", WASTE},
+    {"!WASTE", WASTE_NEGATED},
     {expire_age_str, EXPIRE_AGE},
     {"force_required", FORCE_REQUIRED},
     {"purge_after", PURGE_AFTER},
@@ -388,10 +400,12 @@ parse_config_file(const rmw_options *cli_user_options,
       st_config_data->force_required = 1;
       break;
     case WASTE:
+    case WASTE_NEGATED:
       {
         st_waste *st_new_waste_ptr =
           parse_line_waste(waste_curr, cfg_node, cli_user_options,
-                           st_location->home_dir, st_config_data->uid);
+                           st_location->home_dir, st_config_data->uid,
+                           st_opt[i].id == WASTE_NEGATED);
         if (st_new_waste_ptr != NULL)
         {
           waste_curr = st_new_waste_ptr;
@@ -439,9 +453,11 @@ init_config_data(st_config *x)
 }
 
 void
-show_folder_line(const char *folder, const bool is_r, const bool is_attached)
+show_folder_line(const char *folder, const bool is_r, const bool is_attached,
+                 const bool no_deposit)
 {
-  printf("%s", folder);
+  /* mirror the config syntax: a leading '!' marks a no-deposit folder */
+  printf("%s%s", no_deposit ? "!" : "", folder);
   if (is_r && verbose)
   {
     /*

--- a/src/config_rmw.c
+++ b/src/config_rmw.c
@@ -61,10 +61,11 @@ WASTE = $HOME/.local/share/Waste\n", stream);
   fputs("\
 # WASTE=/mnt/flash/.Trash-$UID, removable\n", stream);
   fputs(_("\n\
-# A folder marked with '!' never receives files when you remove them.\n\
-# rmw can still list, restore, and purge files that are already in it.\n"), stream);
+# The 'no-add' attribute means rmw never puts files in this folder when\n\
+# you remove them. rmw can still list, restore, and purge what is\n\
+# already inside it.\n"), stream);
   fputs("\
-# !WASTE = $HOME/.local/share/Trash\n", stream);
+# WASTE = $HOME/.local/share/Trash, no-add\n", stream);
   fputs(_("\n\
 # How many days should items be allowed to stay in the waste\n\
 # directories before they are permanently deleted\n\
@@ -177,21 +178,24 @@ realize_str(char *str, const char *homedir, const char *uid)
 static st_waste *
 parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
                  const rmw_options *cli_user_options,
-                 const char *homedir, const char *uid,
-                 const bool no_deposit)
+                 const char *homedir, const char *uid)
 {
   bool removable = 0;
+  bool no_add = 0;
   char *attr = NULL;
   canfigger_free_current_attr_str_advance(node->attributes, &attr);
-  if (attr)
+  while (attr)
   {
     if (strcmp("removable", attr) == 0)
       removable = 1;
+    else if (strcmp("no-add", attr) == 0)
+      no_add = 1;
     else
     {
       print_msg_warn();
-      printf("ignoring invalid attribute: '%s'\n", node->attributes->str);
+      printf("ignoring invalid attribute: '%s'\n", attr);
     }
+    canfigger_free_current_attr_str_advance(node->attributes, &attr);
   }
 
   bufchk_len(strlen(node->value) + 1, PATH_MAX, __func__, __LINE__);
@@ -209,13 +213,13 @@ parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
 
   bool is_attached =
     (check_pathname_state(tmp_waste_parent_folder) == EEXIST);
-  /* A "!WASTE" folder that doesn't exist is skipped rather than created:
+  /* A "no-add" folder that doesn't exist is skipped rather than created:
    * it can never receive files, and purge exits on an unopenable info dir. */
-  if ((removable || no_deposit) && !is_attached)
+  if ((removable || no_add) && !is_attached)
   {
     if (cli_user_options->list)
       show_folder_line(tmp_waste_parent_folder, removable, is_attached,
-                       no_deposit);
+                       no_add);
 
     return NULL;
   }
@@ -238,7 +242,7 @@ parse_line_waste(st_waste *waste_curr, struct Canfigger *node,
   waste_curr->next_node = NULL;
 
   waste_curr->removable = removable ? true : false;
-  waste_curr->no_deposit = no_deposit;
+  waste_curr->no_add = no_add;
 
   /* make the parent... */
   waste_curr->parent = malloc(strlen(tmp_waste_parent_folder) + 1);
@@ -343,7 +347,6 @@ parse_config_file(const rmw_options *cli_user_options,
   {
     EXPIRE_AGE,
     WASTE,
-    WASTE_NEGATED,
     FORCE_REQUIRED,
     PURGE_AFTER,
     INVALID_OPTION
@@ -357,7 +360,6 @@ parse_config_file(const rmw_options *cli_user_options,
 
   struct opt st_opt[] = {
     {"WASTE", WASTE},
-    {"!WASTE", WASTE_NEGATED},
     {expire_age_str, EXPIRE_AGE},
     {"force_required", FORCE_REQUIRED},
     {"purge_after", PURGE_AFTER},
@@ -400,12 +402,10 @@ parse_config_file(const rmw_options *cli_user_options,
       st_config_data->force_required = 1;
       break;
     case WASTE:
-    case WASTE_NEGATED:
       {
         st_waste *st_new_waste_ptr =
           parse_line_waste(waste_curr, cfg_node, cli_user_options,
-                           st_location->home_dir, st_config_data->uid,
-                           st_opt[i].id == WASTE_NEGATED);
+                           st_location->home_dir, st_config_data->uid);
         if (st_new_waste_ptr != NULL)
         {
           waste_curr = st_new_waste_ptr;
@@ -454,22 +454,28 @@ init_config_data(st_config *x)
 
 void
 show_folder_line(const char *folder, const bool is_r, const bool is_attached,
-                 const bool no_deposit)
+                 const bool no_add)
 {
-  /* mirror the config syntax: a leading '!' marks a no-deposit folder.
-   * Only under -v: plain -l stays a bare list of paths, fit for piping
-   * to du and friends. */
-  printf("%s%s", (no_deposit && verbose) ? "!" : "", folder);
-  if (is_r && verbose)
+  /* Plain -l stays a bare list of paths, fit for piping to du and friends;
+   * annotations are shown only under -v. */
+  printf("%s", folder);
+  if (verbose)
   {
-    /*
-     * These lines are separated to ease translation
-     *
-     */
-    printf(" (");
-    printf(_("removable, "));
-    /* TRANSLATORS: context - "a mounted device or filesystem is presently attached or mounted" */
-    printf("%s)", is_attached == true ? _("attached") : _("detached"));
+    if (is_r)
+    {
+      /*
+       * These lines are separated to ease translation
+       *
+       */
+      printf(" (");
+      printf(_("removable, "));
+      /* TRANSLATORS: context - "a mounted device or filesystem is presently attached or mounted" */
+      printf("%s)", is_attached == true ? _("attached") : _("detached"));
+    }
+    if (no_add)
+      /* TRANSLATORS: marks a waste folder that never receives new files
+       * (configured with the 'no-add' attribute) */
+      printf(" (%s)", _("no-add"));
   }
 
   putchar('\n');

--- a/src/config_rmw.h
+++ b/src/config_rmw.h
@@ -50,4 +50,5 @@ parse_config_file(const rmw_options * cli_user_options,
 void init_config_data(st_config * x);
 
 void
-show_folder_line(const char *folder, const bool is_r, const bool is_attached);
+show_folder_line(const char *folder, const bool is_r, const bool is_attached,
+                 const bool no_deposit);

--- a/src/config_rmw.h
+++ b/src/config_rmw.h
@@ -57,4 +57,4 @@ void init_config_data(st_config * x);
 
 void
 show_folder_line(const char *folder, const bool is_r, const bool is_attached,
-                 const bool no_deposit);
+                 const bool no_add);

--- a/src/config_rmw.h
+++ b/src/config_rmw.h
@@ -28,6 +28,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define ENV_RMW_FAKE_HOME "RMW_FAKE_HOME"
 
+/* Discovery scans real mount points, so it is suppressed under
+ * RMW_FAKE_HOME. Setting RMW_CHECK_DISCOVERY re-enables it so a test can
+ * exercise discovery against mounts it controls (e.g. in a private mount
+ * namespace). */
+#define ENV_RMW_CHECK_DISCOVERY "RMW_CHECK_DISCOVERY"
+
 extern const char *expire_age_str;
 
 typedef struct

--- a/src/main.c
+++ b/src/main.c
@@ -252,7 +252,6 @@ list_waste_folders(st_waste *waste_head)
     waste_curr = waste_curr->next_node;
   }
 
-  dispose_waste(waste_head);
   return;
 }
 
@@ -679,6 +678,51 @@ discover_existing_topdir_trashes(st_config *st_config_data,
 }
 
 
+/* With -l -v: show spec $topdir locations on eligible mounts that aren't in
+ * the waste list yet — where a trash dir would be created on demand. */
+static void
+list_candidate_topdirs(const st_config *st_config_data,
+                       const st_loc *st_location)
+{
+  char *home_trash_dir = home_trash_dir_for(st_location->home_dir);
+
+  struct stat st;
+  dev_t home_dev = 0;
+  if (lstat(st_location->home_dir, &st) == 0)
+    home_dev = st.st_dev;
+
+  st_mount_trash *mts =
+    build_mount_trash_list(st_config_data->uid, home_trash_dir, home_dev);
+
+  bool have_header = false;
+  for (st_mount_trash *n = mts; n != NULL; n = n->next)
+  {
+    bool listed = false;
+    for (st_waste *w = st_config_data->st_waste_folder_props_head;
+         w != NULL; w = w->next_node)
+    {
+      if (strcmp(w->parent, n->trash_dir) == 0)
+      {
+        listed = true;
+        break;
+      }
+    }
+    if (listed)
+      continue;
+
+    if (!have_header)
+    {
+      printf(_("\nCandidate trash locations (created when needed):\n"));
+      have_header = true;
+    }
+    printf("  %s\n", n->trash_dir);
+  }
+
+  free_mount_trash_list(mts);
+  free(home_trash_dir);
+}
+
+
 static const st_loc *
 get_locations(const char *alt_config_file)
 {
@@ -874,27 +918,9 @@ Please check your configuration file and permissions\
   if (cli_user_options.list)
   {
     list_waste_folders(st_config_data.st_waste_folder_props_head);
-    return 0;
-  }
-
-  if (cli_user_options.list_all_trash)
-  {
-    char *home_trash_dir = home_trash_dir_for(st_location->home_dir);
-
-    struct stat st;
-    dev_t home_dev = 0;
-    if (lstat(st_location->home_dir, &st) == 0)
-      home_dev = st.st_dev;
-
-    st_mount_trash *head =
-      build_mount_trash_list(st_config_data.uid, home_trash_dir, home_dev);
-    for (st_mount_trash *n = head; n != NULL; n = n->next)
-    {
-      bool exists = (check_pathname_state(n->trash_dir) == EEXIST);
-      printf("%c %s\n", exists ? '*' : ' ', n->trash_dir);
-    }
-    free_mount_trash_list(head);
-    free(home_trash_dir);
+    /* gated like discovery above, so tests don't see host mounts */
+    if (verbose && getenv(ENV_RMW_FAKE_HOME) == NULL)
+      list_candidate_topdirs(&st_config_data, st_location);
     dispose_waste(st_config_data.st_waste_folder_props_head);
     return 0;
   }

--- a/src/main.c
+++ b/src/main.c
@@ -247,7 +247,8 @@ list_waste_folders(st_waste *waste_head)
   st_waste *waste_curr = waste_head;
   while (waste_curr != NULL)
   {
-    show_folder_line(waste_curr->parent, waste_curr->removable, is_attached);
+    show_folder_line(waste_curr->parent, waste_curr->removable, is_attached,
+                     waste_curr->no_deposit);
     waste_curr = waste_curr->next_node;
   }
 
@@ -391,6 +392,12 @@ damage of 5000 hp. You feel satisfied.\n"));
     waste_curr = waste_head;
     while (waste_curr != NULL)
     {
+      /* "!WASTE" folders are never a removal destination */
+      if (waste_curr->no_deposit)
+      {
+        waste_curr = waste_curr->next_node;
+        continue;
+      }
       if (waste_curr->dev_num == st_target.dev_num ||
           (waste_curr->is_ficlone_fs && src_is_ficlone))
       {
@@ -527,6 +534,7 @@ damage of 5000 hp. You feel satisfied.\n"));
           new_node->media_root = fb_mount;       /* takes ownership */
           fb_mount = NULL;
           new_node->removable = false;
+          new_node->no_deposit = false;
           new_node->is_ficlone_fs = is_ficlone_fs(fb_trash);
           new_node->dev_num = fb_st.st_dev;
           new_node->next_node = NULL;
@@ -644,6 +652,7 @@ discover_existing_topdir_trashes(st_config *st_config_data,
     new_node->media_root = (n->mount_path != NULL)
       ? strdup(n->mount_path) : NULL;
     new_node->removable = false;
+    new_node->no_deposit = false;
     new_node->is_ficlone_fs = n->is_ficlone_fs;
     new_node->dev_num = tst.st_dev;
     new_node->next_node = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -248,7 +248,7 @@ list_waste_folders(st_waste *waste_head)
   while (waste_curr != NULL)
   {
     show_folder_line(waste_curr->parent, waste_curr->removable, is_attached,
-                     waste_curr->no_deposit);
+                     waste_curr->no_add);
     waste_curr = waste_curr->next_node;
   }
 
@@ -391,8 +391,8 @@ damage of 5000 hp. You feel satisfied.\n"));
     waste_curr = waste_head;
     while (waste_curr != NULL)
     {
-      /* "!WASTE" folders are never a removal destination */
-      if (waste_curr->no_deposit)
+      /* "no-add" folders are never a removal destination */
+      if (waste_curr->no_add)
       {
         waste_curr = waste_curr->next_node;
         continue;
@@ -533,7 +533,7 @@ damage of 5000 hp. You feel satisfied.\n"));
           new_node->media_root = fb_mount;       /* takes ownership */
           fb_mount = NULL;
           new_node->removable = false;
-          new_node->no_deposit = false;
+          new_node->no_add = false;
           new_node->is_ficlone_fs = is_ficlone_fs(fb_trash);
           new_node->dev_num = fb_st.st_dev;
           new_node->next_node = NULL;
@@ -651,7 +651,7 @@ discover_existing_topdir_trashes(st_config *st_config_data,
     new_node->media_root = (n->mount_path != NULL)
       ? strdup(n->mount_path) : NULL;
     new_node->removable = false;
-    new_node->no_deposit = false;
+    new_node->no_add = false;
     new_node->is_ficlone_fs = n->is_ficlone_fs;
     new_node->dev_num = tst.st_dev;
     new_node->next_node = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "messages.h"
 #include "ficlone.h"
 #include "trashinfo.h"
+#include "topdir_trash.h"
 
 
 /*!
@@ -468,6 +469,63 @@ damage of 5000 hp. You feel satisfied.\n"));
 
     if (!waste_curr)
     {
+      /* No configured WASTE matched. Fall back to the spec-compliant
+       * $topdir trash for this file's mount, creating it on demand. */
+      char *fb_trash = find_topdir_trash(arg, get_user_uid_str());
+      char *fb_files = NULL;
+      char *fb_info = NULL;
+      bool fb_ok = false;
+      if (fb_trash != NULL)
+      {
+        fb_files = join_paths(fb_trash, "files");
+        fb_info = join_paths(fb_trash, "info");
+        fb_ok = true;
+        if (check_pathname_state(fb_files) == ENOENT
+            && rmw_mkdir(fb_files) != 0)
+          fb_ok = false;
+        if (fb_ok
+            && check_pathname_state(fb_info) == ENOENT
+            && rmw_mkdir(fb_info) != 0)
+          fb_ok = false;
+      }
+
+      if (fb_ok)
+      {
+        struct stat fb_st;
+        if (lstat(fb_trash, &fb_st) != 0)
+          fb_ok = false;
+        else
+        {
+          st_waste *new_node = malloc(sizeof *new_node);
+          if (!new_node)
+            fatal_malloc();
+          new_node->parent = fb_trash;
+          new_node->files = fb_files;
+          new_node->info = fb_info;
+          new_node->len_files = strlen(fb_files);
+          new_node->len_info = strlen(fb_info);
+          new_node->media_root = NULL;
+          new_node->removable = false;
+          new_node->is_ficlone_fs = is_ficlone_fs(fb_trash);
+          new_node->dev_num = fb_st.st_dev;
+          new_node->next_node = NULL;
+
+          st_waste *tail = waste_head;
+          while (tail->next_node != NULL)
+            tail = tail->next_node;
+          new_node->prev_node = tail;
+          tail->next_node = new_node;
+
+          verbose_printf(1, "fallback trash: %s\n", fb_trash);
+          free(st_target.real_path);
+          file_arg--;
+          continue;
+        }
+      }
+
+      free(fb_trash);
+      free(fb_files);
+      free(fb_info);
       printf(_(" :'%s' not ReMoved:\n"), argv[file_arg]);
       printf(_
              ("No WASTE folder defined in '%s' that resides on the same filesystem.\n"),
@@ -683,6 +741,37 @@ Please check your configuration file and permissions\
   if (cli_user_options.list)
   {
     list_waste_folders(st_config_data.st_waste_folder_props_head);
+    return 0;
+  }
+
+  if (cli_user_options.list_all_trash)
+  {
+    const char *xdg_data = getenv("XDG_DATA_HOME");
+    char *home_trash_dir;
+    if (xdg_data != NULL && *xdg_data != '\0')
+      home_trash_dir = join_paths(xdg_data, "Trash");
+    else
+    {
+      char *xdg_default = join_paths(st_location->home_dir, ".local/share");
+      home_trash_dir = join_paths(xdg_default, "Trash");
+      free(xdg_default);
+    }
+
+    struct stat st;
+    dev_t home_dev = 0;
+    if (lstat(st_location->home_dir, &st) == 0)
+      home_dev = st.st_dev;
+
+    st_mount_trash *head =
+      build_mount_trash_list(st_config_data.uid, home_trash_dir, home_dev);
+    for (st_mount_trash *n = head; n != NULL; n = n->next)
+    {
+      bool exists = (check_pathname_state(n->trash_dir) == EEXIST);
+      printf("%c %s\n", exists ? '*' : ' ', n->trash_dir);
+    }
+    free_mount_trash_list(head);
+    free(home_trash_dir);
+    dispose_waste(st_config_data.st_waste_folder_props_head);
     return 0;
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -550,6 +550,103 @@ damage of 5000 hp. You feel satisfied.\n"));
 }
 
 
+/* Returns a newly-malloc'd path to $XDG_DATA_HOME/Trash (or
+ * $home_dir/.local/share/Trash if XDG_DATA_HOME is unset). */
+static char *
+home_trash_dir_for(const char *home_dir)
+{
+  const char *xdg_data = getenv("XDG_DATA_HOME");
+  if (xdg_data != NULL && *xdg_data != '\0')
+    return join_paths(xdg_data, "Trash");
+  char *xdg_default = join_paths(home_dir, ".local/share");
+  char *trash = join_paths(xdg_default, "Trash");
+  free(xdg_default);
+  return trash;
+}
+
+
+/* After parse_config_file(), augment the in-memory waste list with any
+ * spec-compliant topdir trash directories that already exist on disk.
+ * This lets restore/list/purge/orphan_maint discover trashes that were
+ * created by the remove_to_waste() fallback in earlier invocations
+ * (i.e. trash dirs not listed in rmwrc). */
+static void
+discover_existing_topdir_trashes(st_config *st_config_data,
+                                 const st_loc *st_location)
+{
+  char *home_trash_dir = home_trash_dir_for(st_location->home_dir);
+
+  struct stat st;
+  dev_t home_dev = 0;
+  if (lstat(st_location->home_dir, &st) == 0)
+    home_dev = st.st_dev;
+
+  st_mount_trash *mts =
+    build_mount_trash_list(st_config_data->uid, home_trash_dir, home_dev);
+
+  for (st_mount_trash *n = mts; n != NULL; n = n->next)
+  {
+    if (check_pathname_state(n->trash_dir) != EEXIST)
+      continue;
+    if (check_pathname_state(n->files_dir) != EEXIST)
+      continue;
+    if (check_pathname_state(n->info_dir) != EEXIST)
+      continue;
+
+    bool already = false;
+    for (st_waste *w = st_config_data->st_waste_folder_props_head;
+         w != NULL; w = w->next_node)
+    {
+      if (strcmp(w->parent, n->trash_dir) == 0)
+      {
+        already = true;
+        break;
+      }
+    }
+    if (already)
+      continue;
+
+    struct stat tst;
+    if (lstat(n->trash_dir, &tst) != 0)
+      continue;
+
+    st_waste *new_node = malloc(sizeof *new_node);
+    if (!new_node)
+      fatal_malloc();
+    new_node->parent = strdup(n->trash_dir);
+    new_node->files = strdup(n->files_dir);
+    new_node->info = strdup(n->info_dir);
+    new_node->len_files = strlen(new_node->files);
+    new_node->len_info = strlen(new_node->info);
+    new_node->media_root = (n->mount_path != NULL)
+      ? strdup(n->mount_path) : NULL;
+    new_node->removable = false;
+    new_node->is_ficlone_fs = n->is_ficlone_fs;
+    new_node->dev_num = tst.st_dev;
+    new_node->next_node = NULL;
+
+    st_waste *tail = st_config_data->st_waste_folder_props_head;
+    if (tail == NULL)
+    {
+      new_node->prev_node = NULL;
+      st_config_data->st_waste_folder_props_head = new_node;
+    }
+    else
+    {
+      while (tail->next_node != NULL)
+        tail = tail->next_node;
+      new_node->prev_node = tail;
+      tail->next_node = new_node;
+    }
+
+    verbose_printf(1, "discovered topdir trash: %s\n", n->trash_dir);
+  }
+
+  free_mount_trash_list(mts);
+  free(home_trash_dir);
+}
+
+
 static const st_loc *
 get_locations(const char *alt_config_file)
 {
@@ -737,6 +834,10 @@ Please check your configuration file and permissions\
   st_config st_config_data;
   init_config_data(&st_config_data);
   parse_config_file(&cli_user_options, &st_config_data, st_location);
+  /* RMW_FAKE_HOME isolates $HOME but not real mount points, so
+   * discovery would pick up host-machine topdir trashes during tests. */
+  if (getenv(ENV_RMW_FAKE_HOME) == NULL)
+    discover_existing_topdir_trashes(&st_config_data, st_location);
 
   if (cli_user_options.list)
   {
@@ -746,16 +847,7 @@ Please check your configuration file and permissions\
 
   if (cli_user_options.list_all_trash)
   {
-    const char *xdg_data = getenv("XDG_DATA_HOME");
-    char *home_trash_dir;
-    if (xdg_data != NULL && *xdg_data != '\0')
-      home_trash_dir = join_paths(xdg_data, "Trash");
-    else
-    {
-      char *xdg_default = join_paths(st_location->home_dir, ".local/share");
-      home_trash_dir = join_paths(xdg_default, "Trash");
-      free(xdg_default);
-    }
+    char *home_trash_dir = home_trash_dir_for(st_location->home_dir);
 
     struct stat st;
     dev_t home_dev = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "topdir_trash.h"
 
 
+static char *home_trash_dir_for(const char *home_dir);
+
+
 /*!
  * Assigns a time string to *tm_str based on the format requested
  */
@@ -258,7 +261,7 @@ list_waste_folders(st_waste *waste_head)
 static int
 remove_to_waste(const int argc,
                 char *const argv[],
-                st_waste *waste_head,
+                st_waste **waste_head,
                 st_time *st_time_var,
                 const st_loc *st_location,
                 const rmw_options *cli_user_options)
@@ -359,7 +362,7 @@ damage of 5000 hp. You feel satisfied.\n"));
 
     /* Make sure the file isn't a waste folder or a file within a waste folder */
     bool is_protected = 0;
-    st_waste *waste_curr = waste_head;
+    st_waste *waste_curr = *waste_head;
     while (waste_curr != NULL)
     {
       if (strncmp
@@ -388,7 +391,7 @@ damage of 5000 hp. You feel satisfied.\n"));
      * happens (provided all the tests are passed.
      */
     bool src_is_ficlone = is_ficlone_fs(arg);
-    waste_curr = waste_head;
+    waste_curr = *waste_head;
     while (waste_curr != NULL)
     {
       /* "no-add" folders are never a removal destination */
@@ -491,13 +494,22 @@ damage of 5000 hp. You feel satisfied.\n"));
 
     if (!waste_curr)
     {
-      /* No configured WASTE matched. Fall back to the spec-compliant
-       * $topdir trash for this file's mount, creating it on demand.
+      /* No configured or discovered WASTE matched. Fall back to the
+       * spec trash for this file's filesystem, created on demand:
+       *   - home filesystem  -> the home trash ($XDG_DATA_HOME/Trash),
+       *     which uses absolute paths (fb_mount stays NULL)
+       *   - other filesystem -> the $topdir trash for its mount
        * Use real_path: g_unix_mount_for() needs an absolute path. */
       char *fb_mount = NULL;
-      char *fb_trash =
-        find_topdir_trash(st_target.real_path, get_user_uid_str(),
-                          &fb_mount);
+      char *fb_trash;
+      struct stat home_st;
+      if (lstat(st_location->home_dir, &home_st) == 0
+          && st_target.dev_num == home_st.st_dev)
+        fb_trash = home_trash_dir_for(st_location->home_dir);
+      else
+        fb_trash =
+          find_topdir_trash(st_target.real_path, get_user_uid_str(),
+                            &fb_mount);
       char *fb_files = NULL;
       char *fb_info = NULL;
       bool fb_ok = false;
@@ -538,11 +550,19 @@ damage of 5000 hp. You feel satisfied.\n"));
           new_node->dev_num = fb_st.st_dev;
           new_node->next_node = NULL;
 
-          st_waste *tail = waste_head;
-          while (tail->next_node != NULL)
-            tail = tail->next_node;
-          new_node->prev_node = tail;
-          tail->next_node = new_node;
+          if (*waste_head == NULL)
+          {
+            new_node->prev_node = NULL;
+            *waste_head = new_node;
+          }
+          else
+          {
+            st_waste *tail = *waste_head;
+            while (tail->next_node != NULL)
+              tail = tail->next_node;
+            new_node->prev_node = tail;
+            tail->next_node = new_node;
+          }
 
           verbose_printf(1, "fallback trash: %s\n", fb_trash);
           fb_attempted_arg = file_arg;
@@ -814,6 +834,15 @@ get_locations(const char *alt_config_file)
 
       print_config(fp);
       close_file(&fp, x.config_file, __func__);
+
+      /* First-run notice: rmw now works with no configuration, so tell the
+       * user where files go by default and how to keep them separate. Shown
+       * only on the run that creates the config. */
+      puts(_("\
+rmw moves each file to the trash on its own filesystem. Files on your\n\
+home filesystem go to ~/.local/share/Trash, the same trash your desktop\n\
+uses. To keep rmw's files in a separate folder instead, uncomment\n\
+'WASTE = $HOME/.local/share/Waste' in the configuration file above.\n"));
     }
     else
     {
@@ -997,7 +1026,7 @@ Please check your configuration file and permissions\
   {
     int result = remove_to_waste(argc,
                                  argv,
-                                 st_config_data.st_waste_folder_props_head,
+                                 &st_config_data.st_waste_folder_props_head,
                                  &st_time_var,
                                  st_location,
                                  &cli_user_options);

--- a/src/main.c
+++ b/src/main.c
@@ -470,8 +470,12 @@ damage of 5000 hp. You feel satisfied.\n"));
     if (!waste_curr)
     {
       /* No configured WASTE matched. Fall back to the spec-compliant
-       * $topdir trash for this file's mount, creating it on demand. */
-      char *fb_trash = find_topdir_trash(arg, get_user_uid_str());
+       * $topdir trash for this file's mount, creating it on demand.
+       * Use real_path: g_unix_mount_for() needs an absolute path. */
+      char *fb_mount = NULL;
+      char *fb_trash =
+        find_topdir_trash(st_target.real_path, get_user_uid_str(),
+                          &fb_mount);
       char *fb_files = NULL;
       char *fb_info = NULL;
       bool fb_ok = false;
@@ -504,7 +508,8 @@ damage of 5000 hp. You feel satisfied.\n"));
           new_node->info = fb_info;
           new_node->len_files = strlen(fb_files);
           new_node->len_info = strlen(fb_info);
-          new_node->media_root = NULL;
+          new_node->media_root = fb_mount;       /* takes ownership */
+          fb_mount = NULL;
           new_node->removable = false;
           new_node->is_ficlone_fs = is_ficlone_fs(fb_trash);
           new_node->dev_num = fb_st.st_dev;
@@ -526,6 +531,7 @@ damage of 5000 hp. You feel satisfied.\n"));
       free(fb_trash);
       free(fb_files);
       free(fb_info);
+      free(fb_mount);
       printf(_(" :'%s' not ReMoved:\n"), argv[file_arg]);
       printf(_
              ("No WASTE folder defined in '%s' that resides on the same filesystem.\n"),

--- a/src/main.c
+++ b/src/main.c
@@ -910,16 +910,20 @@ Please check your configuration file and permissions\
   st_config st_config_data;
   init_config_data(&st_config_data);
   parse_config_file(&cli_user_options, &st_config_data, st_location);
-  /* RMW_FAKE_HOME isolates $HOME but not real mount points, so
-   * discovery would pick up host-machine topdir trashes during tests. */
-  if (getenv(ENV_RMW_FAKE_HOME) == NULL)
+  /* RMW_FAKE_HOME isolates $HOME but not real mount points, so discovery
+   * would pick up host-machine topdir trashes during tests. A test that
+   * specifically exercises discovery sets RMW_CHECK_DISCOVERY to re-enable
+   * it against mounts it controls. */
+  bool run_discovery = getenv(ENV_RMW_FAKE_HOME) == NULL
+    || getenv(ENV_RMW_CHECK_DISCOVERY) != NULL;
+  if (run_discovery)
     discover_existing_topdir_trashes(&st_config_data, st_location);
 
   if (cli_user_options.list)
   {
     list_waste_folders(st_config_data.st_waste_folder_props_head);
     /* gated like discovery above, so tests don't see host mounts */
-    if (verbose && getenv(ENV_RMW_FAKE_HOME) == NULL)
+    if (verbose && run_discovery)
       list_candidate_topdirs(&st_config_data, st_location);
     dispose_waste(st_config_data.st_waste_folder_props_head);
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -271,6 +271,10 @@ remove_to_waste(const int argc,
   int n_err = 0;
   int removed_files_ctr = 0;
   int file_arg;
+  /* The topdir fallback retries via file_arg--; cap it to one attempt per
+     file so a fallback trash that still can't receive the file (e.g. an
+     unresolvable mount) can't loop forever. */
+  int fb_attempted_arg = -1;
   for (file_arg = optind; file_arg < argc; file_arg++)
   {
     if (*argv[file_arg] == '\0')
@@ -429,7 +433,19 @@ damage of 5000 hp. You feel satisfied.\n"));
             /* same device: simple rename */
             r_result = rename(src, dst);
             if (r_result != 0 && errno == EXDEV)
-              r_result = ficlone_move(src, dst);
+            {
+              /* Same device but a different mount (e.g. a bind mount):
+                 rename can't cross it. Try reflink only where it can
+                 work; otherwise skip this waste so the $topdir fallback
+                 below runs. */
+              if (src_is_ficlone)
+                r_result = ficlone_move(src, dst);
+              if (r_result != 0)
+              {
+                waste_curr = waste_curr->next_node;
+                continue;
+              }
+            }
           }
         }
 
@@ -493,7 +509,7 @@ damage of 5000 hp. You feel satisfied.\n"));
           fb_ok = false;
       }
 
-      if (fb_ok)
+      if (fb_ok && fb_attempted_arg != file_arg)
       {
         struct stat fb_st;
         if (lstat(fb_trash, &fb_st) != 0)
@@ -522,6 +538,7 @@ damage of 5000 hp. You feel satisfied.\n"));
           tail->next_node = new_node;
 
           verbose_printf(1, "fallback trash: %s\n", fb_trash);
+          fb_attempted_arg = file_arg;
           free(st_target.real_path);
           file_arg--;
           continue;

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,6 +31,7 @@ src = [
   'purging.c',
   'messages.c',
   'time_rmw.c',
+  'topdir_trash.c',
   'trashinfo.c',
   'utils.c',
 ]
@@ -62,7 +63,9 @@ endif
 
 config_h = configure_file(output: 'config.h', configuration: conf)
 
-deps_librmw = [dep_intl, canfigger_dep, dep_menu, dep_curses, glib_dep, gio_dep]
+gio_unix_dep = dependency('gio-unix-2.0')
+
+deps_librmw = [dep_intl, canfigger_dep, dep_menu, dep_curses, glib_dep, gio_dep, gio_unix_dep]
 
 lib_rmw = static_library(
   'rmw',

--- a/src/meson.build
+++ b/src/meson.build
@@ -65,7 +65,15 @@ config_h = configure_file(output: 'config.h', configuration: conf)
 
 gio_unix_dep = dependency('gio-unix-2.0')
 
-deps_librmw = [dep_intl, canfigger_dep, dep_menu, dep_curses, glib_dep, gio_dep, gio_unix_dep]
+deps_librmw = [
+  dep_intl,
+  canfigger_dep,
+  dep_menu,
+  dep_curses,
+  glib_dep,
+  gio_dep,
+  gio_unix_dep,
+]
 
 lib_rmw = static_library(
   'rmw',

--- a/src/parse_cli_options.c
+++ b/src/parse_cli_options.c
@@ -39,6 +39,7 @@ typedef enum
   CONFIG,
   DRY_RUN,
   LIST,
+  LIST_ALL_TRASH,
   PURGE,
   ORPHANED,
   RESTORE,
@@ -64,6 +65,7 @@ static struct cli_opt
   {CONFIG, "config"},
   {DRY_RUN, "dry-run"},
   {LIST, "list"},
+  {LIST_ALL_TRASH, "list-all-trash"},
   {PURGE, "purge"},
   {ORPHANED, "orphaned"},
   {RESTORE, "restore"},
@@ -110,6 +112,10 @@ Restore FILE(s) from a WASTE directory"));
   printf(_("\
   -l, --%s                list waste directories\n\
 "), cli_opt[LIST].str);
+  printf(_("\
+  -L, --%s      list all candidate trash folders (temporary)\n\
+                            (* prefix = directory exists)\n\
+"), cli_opt[LIST_ALL_TRASH].str);
   printf(_("\
   -g[N_DAYS], --%s[=N_DAYS]\n\
                             purge expired files;\n\
@@ -235,6 +241,7 @@ init_rmw_options(rmw_options *x)
   x->most_recent_list = false;
   x->force = 0;
   x->list = false;
+  x->list_all_trash = false;
   x->alt_config_file = NULL;
 }
 
@@ -248,6 +255,7 @@ parse_cli_options(const int argc, char *const argv[], rmw_options *options)
     {cli_opt[CONFIG].str, 1, NULL, 'c'},
     {cli_opt[DRY_RUN].str, 0, NULL, 'n'},
     {cli_opt[LIST].str, 0, NULL, 'l'},
+    {cli_opt[LIST_ALL_TRASH].str, 0, NULL, 'L'},
     {cli_opt[PURGE].str, 2, NULL, 'g'},
     {cli_opt[ORPHANED].str, 0, NULL, 'o'},
     {cli_opt[RESTORE].str, 1, NULL, 'z'},
@@ -265,7 +273,7 @@ parse_cli_options(const int argc, char *const argv[], rmw_options *options)
 
   int c;
   while ((c =
-          getopt_long(argc, argv, "hvc:g::oz:lnsumwVfrR", long_options,
+          getopt_long(argc, argv, "hvc:g::oz:lLnsumwVfrR", long_options,
                       NULL)) != -1)
   {
     switch (c)
@@ -288,6 +296,9 @@ parse_cli_options(const int argc, char *const argv[], rmw_options *options)
       break;
     case 'l':
       options->list = true;
+      break;
+    case 'L':
+      options->list_all_trash = true;
       break;
     case 'g':
       /* Ignore if used twice, but parse it if --purge was given no argument the first time */

--- a/src/parse_cli_options.c
+++ b/src/parse_cli_options.c
@@ -39,7 +39,6 @@ typedef enum
   CONFIG,
   DRY_RUN,
   LIST,
-  LIST_ALL_TRASH,
   PURGE,
   ORPHANED,
   RESTORE,
@@ -65,7 +64,6 @@ static struct cli_opt
   {CONFIG, "config"},
   {DRY_RUN, "dry-run"},
   {LIST, "list"},
-  {LIST_ALL_TRASH, "list-all-trash"},
   {PURGE, "purge"},
   {ORPHANED, "orphaned"},
   {RESTORE, "restore"},
@@ -111,11 +109,8 @@ Restore FILE(s) from a WASTE directory"));
 "), cli_opt[CONFIG].str);
   printf(_("\
   -l, --%s                list waste directories\n\
+                            (with -v: also candidate trash locations)\n\
 "), cli_opt[LIST].str);
-  printf(_("\
-  -L, --%s      list all candidate trash folders (temporary)\n\
-                            (* prefix = directory exists)\n\
-"), cli_opt[LIST_ALL_TRASH].str);
   printf(_("\
   -g[N_DAYS], --%s[=N_DAYS]\n\
                             purge expired files;\n\
@@ -241,7 +236,6 @@ init_rmw_options(rmw_options *x)
   x->most_recent_list = false;
   x->force = 0;
   x->list = false;
-  x->list_all_trash = false;
   x->alt_config_file = NULL;
 }
 
@@ -255,7 +249,6 @@ parse_cli_options(const int argc, char *const argv[], rmw_options *options)
     {cli_opt[CONFIG].str, 1, NULL, 'c'},
     {cli_opt[DRY_RUN].str, 0, NULL, 'n'},
     {cli_opt[LIST].str, 0, NULL, 'l'},
-    {cli_opt[LIST_ALL_TRASH].str, 0, NULL, 'L'},
     {cli_opt[PURGE].str, 2, NULL, 'g'},
     {cli_opt[ORPHANED].str, 0, NULL, 'o'},
     {cli_opt[RESTORE].str, 1, NULL, 'z'},
@@ -273,7 +266,7 @@ parse_cli_options(const int argc, char *const argv[], rmw_options *options)
 
   int c;
   while ((c =
-          getopt_long(argc, argv, "hvc:g::oz:lLnsumwVfrR", long_options,
+          getopt_long(argc, argv, "hvc:g::oz:lnsumwVfrR", long_options,
                       NULL)) != -1)
   {
     switch (c)
@@ -296,9 +289,6 @@ parse_cli_options(const int argc, char *const argv[], rmw_options *options)
       break;
     case 'l':
       options->list = true;
-      break;
-    case 'L':
-      options->list_all_trash = true;
       break;
     case 'g':
       /* Ignore if used twice, but parse it if --purge was given no argument the first time */

--- a/src/parse_cli_options.h
+++ b/src/parse_cli_options.h
@@ -42,6 +42,10 @@ typedef struct
 
   /*! list waste folder option */
   bool list;
+
+  /*! list all candidate trash folders (FreeDesktop topdir enumeration);
+   * temporary diagnostic flag while iss-525 work is in progress */
+  bool list_all_trash;
 } rmw_options;
 
 

--- a/src/parse_cli_options.h
+++ b/src/parse_cli_options.h
@@ -42,10 +42,6 @@ typedef struct
 
   /*! list waste folder option */
   bool list;
-
-  /*! list all candidate trash folders (FreeDesktop topdir enumeration);
-   * temporary diagnostic flag while iss-525 work is in progress */
-  bool list_all_trash;
 } rmw_options;
 
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -305,38 +305,39 @@ insertion_sort(ITEM **a, const int n)
 
 
 /*
- * Returns the waste node whose parent path best matches the current
- * working directory, using longest common path-component prefix.
- * Returns NULL if waste_head is NULL or no match is found.
+ * Returns the waste node whose parent path is "nearest" to dir: the one
+ * sharing the longest path-component prefix with it. A waste nested below
+ * dir is not eligible -- such a trash serves a subdirectory, not the
+ * location dir is in (this matters now that discovery can add trashes from
+ * deep in the tree). Returns NULL if waste_head is NULL or nothing shares a
+ * path component with dir.
  */
 static st_waste *
-get_nearest_waste(st_waste *waste_head)
+get_nearest_waste(st_waste *waste_head, const char *dir)
 {
-  char cwdbuf[PATH_MAX];
-
-  if (getcwd(cwdbuf, sizeof cwdbuf) == NULL)
-  {
-    diag(DIAG_ERR, "getcwd: %s\n", strerror(errno));
-    return NULL;
-  }
-
   st_waste *best = NULL;
   size_t best_len = 0;
 
   for (st_waste * curr = waste_head; curr != NULL; curr = curr->next_node)
   {
+    const char *p = curr->parent;
     size_t i = 0;
     size_t last_sep = 0;
 
-    while (curr->parent[i] && cwdbuf[i] && curr->parent[i] == cwdbuf[i])
+    while (p[i] && dir[i] && p[i] == dir[i])
     {
-      if (cwdbuf[i] == '/')
+      if (dir[i] == '/')
         last_sep = i;
       i++;
     }
 
-    /* ensure we matched on a full component boundary */
-    if (cwdbuf[i] == '/' || cwdbuf[i] == '\0')
+    /* Skip a waste nested below dir (dir is a path prefix of the waste's
+     * parent): it serves a subdirectory, not where we are. */
+    if (dir[i] == '\0' && p[i] == '/')
+      continue;
+
+    /* The waste's parent is itself a path prefix of dir: count all of it. */
+    if (p[i] == '\0' && (dir[i] == '/' || dir[i] == '\0'))
       last_sep = i;
 
     if (last_sep > best_len)
@@ -362,7 +363,12 @@ int
 restore_select(st_waste *waste_head, st_time *st_time_var,
                const rmw_options *cli_user_options)
 {
-  st_waste *waste_curr = get_nearest_waste(waste_head);
+  char cwdbuf[PATH_MAX];
+  st_waste *waste_curr = NULL;
+  if (getcwd(cwdbuf, sizeof cwdbuf) != NULL)
+    waste_curr = get_nearest_waste(waste_head, cwdbuf);
+  else
+    diag(DIAG_ERR, "getcwd: %s\n", strerror(errno));
   if (waste_curr == NULL)
     waste_curr = waste_head;
   const int start_line_bottom = 7;
@@ -633,6 +639,38 @@ test_create_file_details_str(void)
 
   return;
 }
+
+static void
+test_get_nearest_waste(void)
+{
+  /* Only ->parent and ->next_node are read by get_nearest_waste(). */
+  st_waste home = { 0 };
+  st_waste child = { 0 };
+  st_waste flash = { 0 };
+  home.parent = "/home/andy/.local/share/Trash";
+  child.parent = "/home/andy/src/rmw-project/.Trash-1000";
+  flash.parent = "/mnt/flash/.Trash-1000";
+
+  /* List the deep child first -- the order that exposed the bug. */
+  child.next_node = &home;
+  home.next_node = &flash;
+  st_waste *head = &child;
+
+  /* From ~/src the child trash is *below* the cwd, so it must be skipped;
+   * the home trash wins even though the child is listed first. */
+  assert(get_nearest_waste(head, "/home/andy/src") == &home);
+
+  /* Inside the child's own subtree, the child trash is nearest. */
+  assert(get_nearest_waste(head, "/home/andy/src/rmw-project/sub") == &child);
+
+  /* On the flash mount, its trash is nearest. */
+  assert(get_nearest_waste(head, "/mnt/flash/docs") == &flash);
+
+  /* An unrelated directory shares no path component: no match. */
+  assert(get_nearest_waste(head, "/var/tmp") == NULL);
+
+  return;
+}
 #endif
 
 int
@@ -640,6 +678,7 @@ main(void)
 {
 #if !defined DISABLE_CURSES
   test_create_file_details_str();
+  test_get_nearest_waste();
 #endif
   return 0;
 }

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -1,0 +1,101 @@
+/*
+This file is part of rmw<https://theimpossibleastronaut.github.io/rmw-website/>
+
+Copyright (C) 2012-2026  Andy Alt (arch_stanton5995@proton.me)
+Other authors: https://github.com/theimpossibleastronaut/rmw/blob/master/AUTHORS.md
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef INC_GLOBALS_H
+#define INC_GLOBALS_H
+#include "globals.h"
+#endif
+
+#include <sys/stat.h>
+#include <gio/gunixmounts.h>
+
+#include "topdir_trash.h"
+#include "messages.h"
+#include "strings_rmw.h"
+#include "utils.h"
+
+
+/*
+ * Per FreeDesktop Trash spec section 1.1:
+ * If $topdir/.Trash exists, is not a symlink, and has the sticky bit set,
+ * return "$topdir/.Trash/$uid". Otherwise return "$topdir/.Trash-$uid".
+ * Returns NULL on unexpected lstat failure. Caller must free.
+ */
+static char *
+trash_path_for_topdir(const char *topdir, const char *uid)
+{
+  char *dot_trash = join_paths(topdir, ".Trash");
+
+  struct stat st;
+  if (lstat(dot_trash, &st) == 0)
+  {
+    if (S_ISLNK(st.st_mode))
+    {
+      print_msg_warn();
+      fprintf(stderr, "%s is a symbolic link; ignoring per trash spec\n",
+              dot_trash);
+    }
+    else if (!(st.st_mode & S_ISVTX))
+    {
+      print_msg_warn();
+      fprintf(stderr, "%s lacks the sticky bit; ignoring per trash spec\n",
+              dot_trash);
+    }
+    else
+    {
+      char *result = join_paths(dot_trash, uid);
+      free(dot_trash);
+      return result;
+    }
+  }
+  else if (errno != ENOENT)
+  {
+    free(dot_trash);
+    perror("lstat");
+    return NULL;
+  }
+
+  free(dot_trash);
+
+  char dot_trash_uid[PATH_MAX];
+  sn_check(snprintf(dot_trash_uid, sizeof dot_trash_uid, ".Trash-%s", uid),
+           sizeof dot_trash_uid);
+  return join_paths(topdir, dot_trash_uid);
+}
+
+
+char *
+find_topdir_trash(const char *file_path, const char *uid)
+{
+  /* g_unix_mount_for/g_unix_mount_get_mount_path/g_unix_mount_free were
+   * deprecated in GLib 2.78 in favour of g_unix_mount_entry_* equivalents.
+   * Suppress warnings until we can set the project minimum to 2.78. */
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  GUnixMountEntry *entry = g_unix_mount_for(file_path, NULL);
+  if (!entry)
+    return NULL;
+
+  const char *topdir = g_unix_mount_get_mount_path(entry);
+  char *result = trash_path_for_topdir(topdir, uid);
+  g_unix_mount_free(entry);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+
+  return result;
+}

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -311,7 +311,11 @@ build_mount_trash_list(const char *uid,
        * existing, writable one is evidence of intent (configured by the
        * user in the past, or created by an older rmw): keep it visible so
        * restore and purge can still reach its contents. access(W_OK)
-       * covers existence, writability, and readonly mounts in one call. */
+       * covers existence, writability, and readonly mounts in one call.
+       * Skip mount roots we can't read (/sys/fs/pstore, docker overlays,
+       * ...) before probing, or the probe spams lstat errors. */
+      if (access(mount_path, R_OK | X_OK) != 0)
+        continue;
       char *t = trash_path_for_topdir(mount_path, uid);
       bool keep = (t != NULL && access(t, W_OK) == 0);
       free(t);

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -218,8 +218,12 @@ trash_path_for_topdir(const char *topdir, const char *uid)
 
 
 char *
-find_topdir_trash(const char *file_path, const char *uid)
+find_topdir_trash(const char *file_path, const char *uid,
+                  char **mount_path_out)
 {
+  if (mount_path_out != NULL)
+    *mount_path_out = NULL;
+
   /* g_unix_mount_for/g_unix_mount_get_mount_path/g_unix_mount_free were
    * deprecated in GLib 2.78 in favour of g_unix_mount_entry_* equivalents.
    * Suppress warnings until we can set the project minimum to 2.78. */
@@ -230,6 +234,8 @@ find_topdir_trash(const char *file_path, const char *uid)
 
   const char *topdir = g_unix_mount_get_mount_path(entry);
   char *result = trash_path_for_topdir(topdir, uid);
+  if (result != NULL && mount_path_out != NULL)
+    *mount_path_out = strdup(topdir);
   g_unix_mount_free(entry);
   G_GNUC_END_IGNORE_DEPRECATIONS
 

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -249,6 +249,7 @@ find_topdir_trash(const char *file_path, const char *uid,
   G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   GList *mounts = g_unix_mounts_get(NULL);
 
+  GUnixMountEntry *best = NULL;
   const char *topdir = NULL;
   size_t best_len = 0;
   for (GList *l = mounts; l != NULL; l = l->next)
@@ -259,12 +260,17 @@ find_topdir_trash(const char *file_path, const char *uid,
     if (len >= best_len && mount_path_prefixes(mp, len, real))
     {
       best_len = len;
+      best = l->data;
       topdir = mp;
     }
   }
 
+  /* Never create a trash dir on an excluded filesystem (tmpfs, network
+   * shares, ...). Desktop file managers refuse to trash there too; the
+   * caller reports that no suitable waste folder exists. A pre-existing
+   * trash on such a mount is honored via build_mount_trash_list instead. */
   char *result = NULL;
-  if (topdir != NULL)
+  if (best != NULL && mount_is_eligible(best))
   {
     result = trash_path_for_topdir(topdir, uid);
     if (result != NULL && mount_path_out != NULL)
@@ -294,12 +300,24 @@ build_mount_trash_list(const char *uid,
   for (GList *l = mounts; l != NULL; l = l->next)
   {
     GUnixMountEntry *entry = l->data;
-    if (!mount_is_eligible(entry))
-      continue;
 
     G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     const char *mount_path = g_unix_mount_get_mount_path(entry);
     G_GNUC_END_IGNORE_DEPRECATIONS
+
+    if (!mount_is_eligible(entry))
+    {
+      /* New trash dirs are never created on excluded filesystems, but an
+       * existing, writable one is evidence of intent (configured by the
+       * user in the past, or created by an older rmw): keep it visible so
+       * restore and purge can still reach its contents. access(W_OK)
+       * covers existence, writability, and readonly mounts in one call. */
+      char *t = trash_path_for_topdir(mount_path, uid);
+      bool keep = (t != NULL && access(t, W_OK) == 0);
+      free(t);
+      if (!keep)
+        continue;
+    }
 
     struct stat st;
     if (lstat(mount_path, &st) != 0)

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #include <sys/stat.h>
+#include <unistd.h>
 #include <gio/gunixmounts.h>
 
 #include "ficlone.h"
@@ -55,7 +56,7 @@ static const char *const fs_type_exclude_list[] = {
   "proc", "sysfs", "devtmpfs", "devpts", "tmpfs",
   "cgroup", "cgroup2", "bpf", "securityfs", "debugfs", "tracefs",
   "pstore", "mqueue", "hugetlbfs", "fusectl", "configfs", "autofs",
-  "binfmt_misc", "rpc_pipefs", "nsfs",
+  "binfmt_misc", "rpc_pipefs", "nsfs", "efivarfs",
   "overlay", "squashfs",
   "cifs", "smbfs", "smb3",
   NULL,
@@ -82,10 +83,17 @@ mount_is_eligible(GUnixMountEntry *entry)
   G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   bool readonly = g_unix_mount_is_readonly(entry);
   const char *fs_type = g_unix_mount_get_fs_type(entry);
+  const char *mount_path = g_unix_mount_get_mount_path(entry);
   G_GNUC_END_IGNORE_DEPRECATIONS
   if (readonly)
     return false;
-  return fs_type_is_eligible(fs_type);
+  if (!fs_type_is_eligible(fs_type))
+    return false;
+  /* Skip mounts the current user cannot write to (e.g. /boot/efi).
+   * access() resolves effective uid/gid against the actual ACL. */
+  if (access(mount_path, W_OK) != 0)
+    return false;
+  return true;
 }
 
 static st_mount_trash *

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -305,6 +305,13 @@ build_mount_trash_list(const char *uid,
     const char *mount_path = g_unix_mount_get_mount_path(entry);
     G_GNUC_END_IGNORE_DEPRECATIONS
 
+    /* Skip mount points that aren't directories. Containers (and some
+     * systemd setups) bind-mount single files like /etc/resolv.conf;
+     * a trash dir can't live under a file, and probing one would error. */
+    struct stat mp_st;
+    if (lstat(mount_path, &mp_st) != 0 || !S_ISDIR(mp_st.st_mode))
+      continue;
+
     if (!mount_is_eligible(entry))
     {
       /* New trash dirs are never created on excluded filesystems, but an
@@ -323,15 +330,11 @@ build_mount_trash_list(const char *uid,
         continue;
     }
 
-    struct stat st;
-    if (lstat(mount_path, &st) != 0)
-      continue;
-
     /* The mount that hosts the home trash already has a node at the head. */
-    if (st.st_dev == home_dev)
+    if (mp_st.st_dev == home_dev)
       continue;
 
-    st_mount_trash *node = new_topdir_node(mount_path, uid, st.st_dev);
+    st_mount_trash *node = new_topdir_node(mount_path, uid, mp_st.st_dev);
     if (node == NULL)
       continue;
 

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -181,17 +181,11 @@ trash_path_for_topdir(const char *topdir, const char *uid)
   if (lstat(dot_trash, &st) == 0)
   {
     if (S_ISLNK(st.st_mode))
-    {
-      print_msg_warn();
-      fprintf(stderr, "%s is a symbolic link; ignoring per trash spec\n",
-              dot_trash);
-    }
+      diag(DIAG_WARN, "%s is a symbolic link; ignoring per trash spec\n",
+           dot_trash);
     else if (!(st.st_mode & S_ISVTX))
-    {
-      print_msg_warn();
-      fprintf(stderr, "%s lacks the sticky bit; ignoring per trash spec\n",
-              dot_trash);
-    }
+      diag(DIAG_WARN, "%s lacks the sticky bit; ignoring per trash spec\n",
+           dot_trash);
     else
     {
       char *result = join_paths(dot_trash, uid);
@@ -201,8 +195,8 @@ trash_path_for_topdir(const char *topdir, const char *uid)
   }
   else if (errno != ENOENT)
   {
+    diag(DIAG_ERR, "lstat %s: %s\n", dot_trash, strerror(errno));
     free(dot_trash);
-    perror("lstat");
     return NULL;
   }
 

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -26,10 +26,144 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <sys/stat.h>
 #include <gio/gunixmounts.h>
 
+#include "ficlone.h"
 #include "topdir_trash.h"
 #include "messages.h"
 #include "strings_rmw.h"
 #include "utils.h"
+
+
+static char *trash_path_for_topdir(const char *topdir, const char *uid);
+
+
+/*
+ * Filesystem types that should not get a trash directory.
+ *
+ * Pseudo-filesystems (no real on-disk storage): proc, sysfs, devtmpfs,
+ * devpts, cgroup*, bpf, securityfs, debugfs, tracefs, pstore, mqueue,
+ * hugetlbfs, fusectl, configfs, autofs, binfmt_misc, rpc_pipefs, nsfs.
+ *
+ * Ephemeral or container-style: tmpfs (reboot wipes it), overlay, squashfs.
+ *
+ * Network shares the spec explicitly leaves undefined (no real numeric uid
+ * model): cifs, smbfs, smb3. All "fuse.*" fs types are excluded too
+ * (uid-mapping semantics vary too widely between fuse backends).
+ *
+ * NFS is NOT excluded: it has a native uid model and the spec permits it.
+ */
+static const char *const fs_type_exclude_list[] = {
+  "proc", "sysfs", "devtmpfs", "devpts", "tmpfs",
+  "cgroup", "cgroup2", "bpf", "securityfs", "debugfs", "tracefs",
+  "pstore", "mqueue", "hugetlbfs", "fusectl", "configfs", "autofs",
+  "binfmt_misc", "rpc_pipefs", "nsfs",
+  "overlay", "squashfs",
+  "cifs", "smbfs", "smb3",
+  NULL,
+};
+
+static bool
+fs_type_is_eligible(const char *fs_type)
+{
+  if (fs_type == NULL)
+    return false;
+  if (g_str_has_prefix(fs_type, "fuse."))
+    return false;
+  for (const char *const *p = fs_type_exclude_list; *p != NULL; p++)
+  {
+    if (g_str_equal(fs_type, *p))
+      return false;
+  }
+  return true;
+}
+
+static bool
+mount_is_eligible(GUnixMountEntry *entry)
+{
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  bool readonly = g_unix_mount_is_readonly(entry);
+  const char *fs_type = g_unix_mount_get_fs_type(entry);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+  if (readonly)
+    return false;
+  return fs_type_is_eligible(fs_type);
+}
+
+static st_mount_trash *
+alloc_mount_trash_node(void)
+{
+  st_mount_trash *node = malloc(sizeof *node);
+  if (node == NULL)
+    fatal_malloc();
+  node->mount_path = NULL;
+  node->trash_dir = NULL;
+  node->files_dir = NULL;
+  node->info_dir = NULL;
+  node->dev_num = 0;
+  node->is_home_trash = false;
+  node->is_ficlone_fs = false;
+  node->next = NULL;
+  return node;
+}
+
+/* The home trash dir may not exist yet at startup. Walk up the path until
+ * we find an existing ancestor so callers (is_ficlone_fs, stat) get a real
+ * filesystem path to probe. Returns a newly-g_malloc'd string, or NULL if
+ * no ancestor up to "/" exists. */
+static char *
+first_existing_ancestor(const char *path)
+{
+  char *probe = g_strdup(path);
+  struct stat st;
+  while (lstat(probe, &st) != 0)
+  {
+    char *parent = g_path_get_dirname(probe);
+    if (g_str_equal(parent, probe))
+    {
+      g_free(probe);
+      g_free(parent);
+      return NULL;
+    }
+    g_free(probe);
+    probe = parent;
+  }
+  return probe;
+}
+
+static st_mount_trash *
+new_home_trash_node(const char *home_trash_dir, dev_t home_dev)
+{
+  st_mount_trash *node = alloc_mount_trash_node();
+  node->trash_dir = strdup(home_trash_dir);
+  node->files_dir = join_paths(home_trash_dir, "files");
+  node->info_dir = join_paths(home_trash_dir, "info");
+  node->dev_num = home_dev;
+  node->is_home_trash = true;
+
+  char *probe = first_existing_ancestor(home_trash_dir);
+  if (probe != NULL)
+  {
+    node->is_ficlone_fs = is_ficlone_fs(probe);
+    g_free(probe);
+  }
+  return node;
+}
+
+static st_mount_trash *
+new_topdir_node(const char *mount_path, const char *uid, dev_t dev_num)
+{
+  char *trash_dir = trash_path_for_topdir(mount_path, uid);
+  if (trash_dir == NULL)
+    return NULL;
+
+  st_mount_trash *node = alloc_mount_trash_node();
+  node->mount_path = strdup(mount_path);
+  node->trash_dir = trash_dir;
+  node->files_dir = join_paths(trash_dir, "files");
+  node->info_dir = join_paths(trash_dir, "info");
+  node->dev_num = dev_num;
+  node->is_ficlone_fs = is_ficlone_fs(mount_path);
+  return node;
+}
 
 
 /*
@@ -98,4 +232,66 @@ find_topdir_trash(const char *file_path, const char *uid)
   G_GNUC_END_IGNORE_DEPRECATIONS
 
   return result;
+}
+
+
+st_mount_trash *
+build_mount_trash_list(const char *uid,
+                       const char *home_trash_dir,
+                       dev_t home_dev)
+{
+  st_mount_trash *head = new_home_trash_node(home_trash_dir, home_dev);
+  st_mount_trash *tail = head;
+
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  GList *mounts = g_unix_mounts_get(NULL);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+
+  for (GList *l = mounts; l != NULL; l = l->next)
+  {
+    GUnixMountEntry *entry = l->data;
+    if (!mount_is_eligible(entry))
+      continue;
+
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    const char *mount_path = g_unix_mount_get_mount_path(entry);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+
+    struct stat st;
+    if (lstat(mount_path, &st) != 0)
+      continue;
+
+    /* The mount that hosts the home trash already has a node at the head. */
+    if (st.st_dev == home_dev)
+      continue;
+
+    st_mount_trash *node = new_topdir_node(mount_path, uid, st.st_dev);
+    if (node == NULL)
+      continue;
+
+    tail->next = node;
+    tail = node;
+  }
+
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  g_list_free_full(mounts, (GDestroyNotify) g_unix_mount_free);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+
+  return head;
+}
+
+
+void
+free_mount_trash_list(st_mount_trash *head)
+{
+  while (head != NULL)
+  {
+    st_mount_trash *next = head->next;
+    free(head->mount_path);
+    free(head->trash_dir);
+    free(head->files_dir);
+    free(head->info_dir);
+    free(head);
+    head = next;
+  }
 }

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -217,6 +217,17 @@ trash_path_for_topdir(const char *topdir, const char *uid)
 }
 
 
+/* True if mount_path is "/" or a whole-component prefix of real_path
+ * ("/a/b" prefixes "/a/b/c" but not "/a/bc"). */
+static bool
+mount_path_prefixes(const char *mount_path, size_t len,
+                    const char *real_path)
+{
+  if (strncmp(real_path, mount_path, len) != 0)
+    return false;
+  return len == 1 || real_path[len] == '/' || real_path[len] == '\0';
+}
+
 char *
 find_topdir_trash(const char *file_path, const char *uid,
                   char **mount_path_out)
@@ -224,20 +235,45 @@ find_topdir_trash(const char *file_path, const char *uid,
   if (mount_path_out != NULL)
     *mount_path_out = NULL;
 
-  /* g_unix_mount_for/g_unix_mount_get_mount_path/g_unix_mount_free were
+  /* g_unix_mount_for() locates a path's mount by walking up until st_dev
+   * changes, which walks straight past a bind mount (same device as its
+   * source) and lands on the parent mount. Instead, take the mount table
+   * entry whose path is the longest prefix of the file's canonical path. */
+  char *real = realpath(file_path, NULL);
+  if (real == NULL)
+    return NULL;
+
+  /* g_unix_mounts_get/g_unix_mount_get_mount_path/g_unix_mount_free were
    * deprecated in GLib 2.78 in favour of g_unix_mount_entry_* equivalents.
    * Suppress warnings until we can set the project minimum to 2.78. */
   G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-  GUnixMountEntry *entry = g_unix_mount_for(file_path, NULL);
-  if (!entry)
-    return NULL;
+  GList *mounts = g_unix_mounts_get(NULL);
 
-  const char *topdir = g_unix_mount_get_mount_path(entry);
-  char *result = trash_path_for_topdir(topdir, uid);
-  if (result != NULL && mount_path_out != NULL)
-    *mount_path_out = strdup(topdir);
-  g_unix_mount_free(entry);
+  const char *topdir = NULL;
+  size_t best_len = 0;
+  for (GList *l = mounts; l != NULL; l = l->next)
+  {
+    const char *mp = g_unix_mount_get_mount_path(l->data);
+    size_t len = strlen(mp);
+    /* >= so the most recent entry wins when a path is overmounted */
+    if (len >= best_len && mount_path_prefixes(mp, len, real))
+    {
+      best_len = len;
+      topdir = mp;
+    }
+  }
+
+  char *result = NULL;
+  if (topdir != NULL)
+  {
+    result = trash_path_for_topdir(topdir, uid);
+    if (result != NULL && mount_path_out != NULL)
+      *mount_path_out = strdup(topdir);
+  }
+
+  g_list_free_full(mounts, (GDestroyNotify) g_unix_mount_free);
   G_GNUC_END_IGNORE_DEPRECATIONS
+  free(real);
 
   return result;
 }

--- a/src/topdir_trash.h
+++ b/src/topdir_trash.h
@@ -1,0 +1,35 @@
+/*
+This file is part of rmw<https://theimpossibleastronaut.github.io/rmw-website/>
+
+Copyright (C) 2012-2026  Andy Alt (arch_stanton5995@proton.me)
+Other authors: https://github.com/theimpossibleastronaut/rmw/blob/master/AUTHORS.md
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "globals.h"
+
+/*
+ * Given a file path and a uid string, returns the spec-compliant trash
+ * directory path for the volume that file_path resides on:
+ *   $topdir/.Trash/$uid   if $topdir/.Trash exists, is not a symlink,
+ *                         and has the sticky bit set
+ *   $topdir/.Trash-$uid   otherwise
+ *
+ * Returns NULL if the mount point cannot be determined or on error.
+ * The caller must free the returned string.
+ */
+char *find_topdir_trash(const char *file_path, const char *uid);

--- a/src/topdir_trash.h
+++ b/src/topdir_trash.h
@@ -31,8 +31,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * Returns NULL if the mount point cannot be determined or on error.
  * The caller must free the returned string.
+ *
+ * If mount_path_out is non-NULL, on success *mount_path_out is set to a
+ * newly-malloc'd copy of the mount path that contains file_path (the
+ * caller must free it). On failure *mount_path_out is set to NULL.
  */
-char *find_topdir_trash(const char *file_path, const char *uid);
+char *find_topdir_trash(const char *file_path, const char *uid,
+                        char **mount_path_out);
 
 
 typedef struct st_mount_trash st_mount_trash;

--- a/src/topdir_trash.h
+++ b/src/topdir_trash.h
@@ -33,3 +33,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * The caller must free the returned string.
  */
 char *find_topdir_trash(const char *file_path, const char *uid);
+
+
+typedef struct st_mount_trash st_mount_trash;
+
+struct st_mount_trash
+{
+  char *mount_path;             /* NULL for the home-trash node */
+  char *trash_dir;              /* $topdir/.Trash{,-}/$uid, or home trash dir */
+  char *files_dir;              /* trash_dir/files */
+  char *info_dir;               /* trash_dir/info  */
+  dev_t dev_num;                /* st_dev of mount_path (or of home-trash volume) */
+  bool is_home_trash;
+  bool is_ficlone_fs;
+  st_mount_trash *next;
+};
+
+/*
+ * Build a linked list of candidate trash locations:
+ *   head: the home-trash node ($XDG_DATA_HOME/Trash semantics)
+ *   tail: one node per eligible mounted filesystem (FreeDesktop topdir rules)
+ *
+ * Mounts whose fs type is in the pseudo/network exclusion list, or that are
+ * read-only, are skipped. The mount that shares dev_num with home_dev is
+ * skipped to avoid duplicating the home-trash node.
+ *
+ * No directories are created; nodes record the spec-compliant paths only.
+ * Returns NULL if even the home-trash node cannot be allocated.
+ * Free with free_mount_trash_list().
+ */
+st_mount_trash *build_mount_trash_list(const char *uid,
+                                       const char *home_trash_dir,
+                                       dev_t home_dev);
+
+void free_mount_trash_list(st_mount_trash *head);

--- a/src/trashinfo.c
+++ b/src/trashinfo.c
@@ -61,30 +61,39 @@ create_trashinfo(rmw_target *st_f_props, st_waste *waste_curr,
     /* Worst case scenario: whole path is escaped, so 3 chars per
      * actual character
      **/
-    char *escaped_path = escape_url(st_f_props->real_path);
-    if (escaped_path == NULL)
-      return close_file(&fp, final_info_dest, __func__);
-
-    char *escaped_path_ptr = escaped_path;
+    /* For a top-level (media_root) waste folder the spec wants a path
+       relative to the mount. Strip media_root from the real path BEFORE
+       escaping, so a mount path containing bytes that get percent-escaped
+       (a space, non-ASCII, ...) can't desync a byte offset. */
+    const char *rel = st_f_props->real_path;
     if (waste_curr->media_root != NULL
-        && (waste_curr->dev_num == st_f_props->dev_num))
+        && waste_curr->dev_num == st_f_props->dev_num)
     {
-      escaped_path_ptr = &escaped_path[strlen(waste_curr->media_root)];
-      if (*escaped_path_ptr == '/')
-        escaped_path_ptr++;
+      size_t mr_len = strlen(waste_curr->media_root);
+      bool under_root = strcmp(waste_curr->media_root, "/") == 0;
+      if (strncmp(rel, waste_curr->media_root, mr_len) == 0
+          && (under_root || rel[mr_len] == '/' || rel[mr_len] == '\0'))
+      {
+        rel += mr_len;
+        if (*rel == '/')
+          rel++;
+      }
       else
       {
         close_file(&fp, final_info_dest, __func__);
         if (unlink(final_info_dest) != 0)
           diag(DIAG_ERR, "unlink: %s\n", strerror(errno));
-        diag_fatal(EXIT_FAILURE,
-                   "Expected a leading '/' in the pathname '%s'\n",
-                   escaped_path_ptr);
+        diag_fatal(EXIT_FAILURE, "'%s' is not under media root '%s'\n",
+                   st_f_props->real_path, waste_curr->media_root);
       }
     }
 
+    char *escaped_path = escape_url(rel);
+    if (escaped_path == NULL)
+      return close_file(&fp, final_info_dest, __func__);
+
     fprintf(fp, "%s\n%s%s\n%s%s\n", trashinfo_template.header,
-            trashinfo_template.path_key, escaped_path_ptr,
+            trashinfo_template.path_key, escaped_path,
             trashinfo_template.deletion_date_key,
             st_time_var->deletion_date);
 

--- a/src/trashinfo.h
+++ b/src/trashinfo.h
@@ -67,11 +67,12 @@ struct st_waste
    */
   bool removable;
 
-  /** Set to <tt>true</tt> when the folder was configured with "!WASTE":
-   * it is never selected as a destination when removing files, but still
-   * participates in listing, restoring, purging, and orphan maintenance.
+  /** Set to <tt>true</tt> for a folder configured with the "no-add"
+   * attribute: it is never selected as a destination when removing files,
+   * but still participates in listing, restoring, purging, and orphan
+   * maintenance.
    */
-  bool no_deposit;
+  bool no_add;
 
   bool is_ficlone_fs;
 };

--- a/src/trashinfo.h
+++ b/src/trashinfo.h
@@ -67,6 +67,12 @@ struct st_waste
    */
   bool removable;
 
+  /** Set to <tt>true</tt> when the folder was configured with "!WASTE":
+   * it is never selected as a destination when removing files, but still
+   * participates in listing, restoring, purging, and orphan maintenance.
+   */
+  bool no_deposit;
+
   bool is_ficlone_fs;
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -95,6 +95,21 @@ check_pathname_state(const char *pathname)
   return -1;
 }
 
+const char *
+get_user_uid_str(void)
+{
+  static char buf[11];          /* uid_t fits in 10 decimal digits + NUL */
+  static bool ready = false;
+  if (!ready)
+  {
+    sn_check(snprintf(buf, sizeof buf, "%u", (unsigned) getuid()),
+             sizeof buf);
+    ready = true;
+  }
+  return buf;
+}
+
+
 void
 dispose_waste(st_waste *node)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,4 +62,10 @@ bool is_dir_f(const char *pathname);
 
 int count_chars(const char c, const char *str);
 
+/*
+ * Returns the current user's uid as a decimal string. The returned pointer
+ * refers to a process-wide static buffer; do not free.
+ */
+const char *get_user_uid_str(void);
+
 #endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,6 +54,15 @@ if strace.found()
   test_env += ['STRACE=' + strace.full_path()]
 endif
 
+exe = executable(
+  'test_topdir_trash',
+  'test_topdir_trash.c',
+  c_args: ['-DRMW_FAKE_HOME="@0@"'.format(RMW_FAKE_HOME)],
+  dependencies: rmw_dep,
+  override_options: ['b_lto=false'],
+)
+test('test_topdir_trash', exe, env: test_env)
+
 foreach s : scripts
   test(
     s,

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,7 @@ scripts = [
   'test_media_root.sh',
   'test_purging.sh',
   'test_restore.sh',
+  'test_waste_negation.sh',
 ]
 
 if host_sys == 'linux'

--- a/test/meson.build
+++ b/test/meson.build
@@ -18,6 +18,7 @@ scripts = [
   'test_restore.sh',
   'test_waste_negation.sh',
   'test_discovery.sh',
+  'test_config_optional.sh',
 ]
 
 if host_sys == 'linux'

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,6 +26,7 @@ if host_sys == 'linux'
   endif
   scripts += ['test_bcachefs.sh']
   scripts += ['test_exdev_fallback.sh']
+  scripts += ['test_discovery_loopback.sh']
 endif
 
 RMW_FAKE_HOME = join_paths(meson.current_build_dir(), 'rmw-tests-home')

--- a/test/meson.build
+++ b/test/meson.build
@@ -20,6 +20,7 @@ scripts = [
   'test_discovery.sh',
   'test_config_optional.sh',
   'test_file_bind_mount.sh',
+  'test_media_root_space.sh',
 ]
 
 if host_sys == 'linux'

--- a/test/meson.build
+++ b/test/meson.build
@@ -19,6 +19,7 @@ scripts = [
   'test_waste_negation.sh',
   'test_discovery.sh',
   'test_config_optional.sh',
+  'test_file_bind_mount.sh',
 ]
 
 if host_sys == 'linux'

--- a/test/meson.build
+++ b/test/meson.build
@@ -23,6 +23,7 @@ if host_sys == 'linux'
     scripts += ['test_btrfs_clone.sh']
   endif
   scripts += ['test_bcachefs.sh']
+  scripts += ['test_exdev_fallback.sh']
 endif
 
 RMW_FAKE_HOME = join_paths(meson.current_build_dir(), 'rmw-tests-home')

--- a/test/meson.build
+++ b/test/meson.build
@@ -17,6 +17,7 @@ scripts = [
   'test_purging.sh',
   'test_restore.sh',
   'test_waste_negation.sh',
+  'test_discovery.sh',
 ]
 
 if host_sys == 'linux'

--- a/test/test_config_optional.sh
+++ b/test/test_config_optional.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Configuration is optional (since 0.10.0): with no configured waste folder,
+# rmw does not exit; it moves a home-filesystem file to the home trash
+# (~/.local/share/Trash), created on demand. First run also creates a
+# comment-only config and prints a one-time notice.
+
+set -ve
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+mkdir -p "$RMW_FAKE_HOME"
+HOME_TRASH="$RMW_FAKE_HOME/.local/share/Trash"
+CONFIG="$RMW_FAKE_HOME/optional.rc"   # does not exist yet -> first run creates it
+
+cd "$RMW_FAKE_HOME"
+
+# --- first run: no config present, no waste configured ---
+echo data > victim
+out=$("$BIN_DIR"/rmw -c "$CONFIG" victim 2>&1)
+echo "$out"
+
+# A config was created, and it carries no active WASTE line (comments only).
+test -f "$CONFIG"
+if grep -Eq '^[[:space:]]*WASTE' "$CONFIG"; then
+  echo "FAIL: a freshly created config must have no active WASTE line"
+  exit 1
+fi
+
+# The one-time first-run notice was shown.
+cmp_substr "$out" "moves each file to the trash"
+
+# The file went to the home trash, created on demand, with an absolute Path.
+test ! -e victim
+test -f "$HOME_TRASH/files/victim"
+test -f "$HOME_TRASH/info/victim.trashinfo"
+grep -q '^Path=/' "$HOME_TRASH/info/victim.trashinfo"
+
+# --- second run: config now exists, notice must not repeat ---
+echo data > victim2
+out2=$("$BIN_DIR"/rmw -c "$CONFIG" victim2 2>&1)
+echo "$out2"
+if cmp_substr "$out2" "moves each file to the trash"; then
+  echo "FAIL: first-run notice must not repeat once the config exists"
+  exit 1
+fi
+test -f "$HOME_TRASH/files/victim2"
+
+echo "PASS: config optional — home file trashed to home trash, notice shown once"
+exit 0

--- a/test/test_discovery.sh
+++ b/test/test_discovery.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Discovery of FreeDesktop $topdir trashes, exercised against mounts the test
+# fully controls inside an unprivileged mount namespace (no sudo).
+#
+# RMW_CHECK_DISCOVERY re-enables discovery under RMW_FAKE_HOME so the binary
+# scans the controlled mounts. The namespace inherits a copy of the host's
+# mount table, so assertions are additive: we check our specific planted
+# paths, not a closed list. Mounts vanish when the namespace exits.
+#
+# Covered: the excluded-filesystem rule (tmpfs is excluded) --
+#   * an existing trash on an excluded fs IS discovered (evidence of intent)
+#   * an excluded fs with no trash is NOT discovered or offered as a candidate
+
+set -ve
+
+# Re-exec the whole script inside a private mount namespace (mapped to root
+# so mount works) before sourcing COMMON, so COMMON runs exactly once. If
+# unprivileged user/mount namespaces are unavailable, skip (77, matching
+# COMMON's SKIP).
+if [ -z "$RMW_DISCOVERY_NS" ]; then
+  if ! unshare --mount --map-root-user true 2>/dev/null; then
+    echo "unprivileged mount namespace unavailable; skipping discovery test."
+    exit 77
+  fi
+  RMW_DISCOVERY_NS=1 exec unshare --mount --map-root-user "$0" "$@"
+fi
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+# Inside --map-root-user the process (and rmw's getuid()) is uid 0, so the
+# trash dir rmw looks for is .Trash-0; id -u agrees.
+TRASH=".Trash-$(id -u)"
+
+ROOT="/tmp/rmw-discovery"
+HAVE="$ROOT/have"              # excluded fs (tmpfs) WITH a pre-existing trash
+BARE="$ROOT/bare"             # excluded fs (tmpfs) with NO trash
+rm -rf "$ROOT"
+mkdir -p "$HAVE" "$BARE"
+mount -t tmpfs none "$HAVE"
+mount -t tmpfs none "$BARE"
+
+mkdir -p "$HAVE/$TRASH/files" "$HAVE/$TRASH/info"
+
+TEST_CONFIG="$RMW_FAKE_HOME/discovery.testrc"
+mkdir -p "$RMW_FAKE_HOME"
+printf 'WASTE = %s/.Waste\nexpire_age = 30\n' "$RMW_FAKE_HOME" > "$TEST_CONFIG"
+RMW="$BIN_DIR/rmw -c $TEST_CONFIG"
+
+# Discovery is on via RMW_CHECK_DISCOVERY even though RMW_FAKE_HOME is set.
+out=$(RMW_CHECK_DISCOVERY=1 $RMW -l 2>&1)
+echo "$out"
+
+# The tmpfs with an existing trash is discovered and listed ...
+cmp_substr "$out" "$HAVE/$TRASH"
+# ... the bare tmpfs is not (no trash dir to honor).
+if cmp_substr "$out" "$BARE/$TRASH"; then
+  echo "FAIL: a trash-less excluded fs must not be discovered"
+  exit 1
+fi
+# ... and it's not offered as a candidate either (excluded fs, -l -v).
+outv=$(RMW_CHECK_DISCOVERY=1 $RMW -l -v 2>&1)
+if cmp_substr "$outv" "$BARE/$TRASH"; then
+  echo "FAIL: an excluded fs must not be a candidate trash location"
+  exit 1
+fi
+
+# A removal reaches the discovered trash on the excluded fs.
+echo data > "$HAVE/victim"
+RMW_CHECK_DISCOVERY=1 $RMW -v "$HAVE/victim"
+test ! -e "$HAVE/victim"
+test -f "$HAVE/$TRASH/files/victim"
+test -f "$HAVE/$TRASH/info/victim.trashinfo"
+
+echo "PASS: existing trash on an excluded fs discovered; trash-less one ignored"
+exit 0

--- a/test/test_discovery_loopback.sh
+++ b/test/test_discovery_loopback.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Discovery against an *eligible* filesystem on its own device, which a bind
+# mount or tmpfs can't provide. Covers the two branches the tmpfs discovery
+# test can't reach:
+#   * an eligible mount not in the config is offered as a candidate (-l -v)
+#   * a file on that mount, with no matching configured WASTE, gets a fresh
+#     $topdir trash created on its own mount and lands there
+#
+# The image is generated at run time (no committed blob); needs passwordless
+# sudo + losetup + mkfs.ext4, otherwise SKIP.
+
+set -ve
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+if ! sudo -n true 2>/dev/null; then
+  echo "sudo not available without password; skipping loopback discovery test."
+  exit "$SKIP"
+fi
+if ! command -v mkfs.ext4 >/dev/null 2>&1; then
+  echo "mkfs.ext4 not available; skipping."
+  exit "$SKIP"
+fi
+
+UID_NUM=$(id -u)
+IMG="/tmp/rmw-disc-ext4.img"
+MNT="/tmp/rmw-disc-mnt"
+TRASH="$MNT/.Trash-$UID_NUM"
+LOOP=""
+
+# shellcheck disable=SC2329
+cleanup() {
+  cd /
+  if mountpoint -q "$MNT" 2>/dev/null; then
+    sudo umount "$MNT"
+  fi
+  if [ -n "$LOOP" ]; then
+    sudo losetup -d "$LOOP" 2>/dev/null || true
+  fi
+  sudo rm -rf "$MNT" "$IMG"
+}
+trap cleanup EXIT
+
+# Clear stale state from an interrupted run.
+if mountpoint -q "$MNT" 2>/dev/null; then
+  sudo umount "$MNT"
+fi
+STALE_LOOP=$(sudo losetup -j "$IMG" -O NAME --noheadings 2>/dev/null)
+if [ -n "$STALE_LOOP" ]; then
+  sudo losetup -d "$STALE_LOOP"
+fi
+sudo rm -rf "$MNT" "$IMG"
+
+# A fresh ext4 on a loop device is its own (eligible) filesystem, distinct
+# from the home device.
+truncate -s 16M "$IMG"
+mkfs.ext4 -qF "$IMG"
+sudo mkdir -p "$MNT"
+LOOP=$(sudo losetup -f --show "$IMG")
+sudo mount "$LOOP" "$MNT"
+sudo chown "$UID_NUM" "$MNT"
+
+TEST_CONFIG="$RMW_FAKE_HOME/disc-loop.testrc"
+mkdir -p "$RMW_FAKE_HOME"
+printf 'WASTE = %s/.Waste\nexpire_age = 30\n' "$RMW_FAKE_HOME" > "$TEST_CONFIG"
+RMW="$BIN_DIR/rmw -c $TEST_CONFIG"
+
+# --- with no trash yet, the eligible mount is offered as a candidate ---
+out=$(RMW_CHECK_DISCOVERY=1 $RMW -l -v 2>&1)
+echo "$out"
+cmp_substr "$out" "$TRASH"
+test ! -e "$TRASH"
+
+# --- a file on the loopback fs has no matching configured WASTE (different
+# device than home), so the fallback creates a trash on its own mount ---
+echo data > "$MNT/victim"
+RMW_CHECK_DISCOVERY=1 $RMW -v "$MNT/victim"
+test ! -e "$MNT/victim"
+test -f "$TRASH/files/victim"
+test -f "$TRASH/info/victim.trashinfo"
+
+# --- now that the trash exists, plain -l discovers and lists it ---
+out=$(RMW_CHECK_DISCOVERY=1 $RMW -l 2>&1)
+cmp_substr "$out" "$TRASH"
+
+echo "PASS: eligible separate-device mount offered as candidate and auto-created"
+exit 0

--- a/test/test_exdev_fallback.sh
+++ b/test/test_exdev_fallback.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Regression test for the same-device / different-mount (EXDEV) fallback.
+#
+# A bind mount shares the underlying filesystem with its source, so a file on
+# the bind mount has the SAME st_dev as a WASTE folder elsewhere on that
+# filesystem (rmw matches it by device) yet rename(2) returns EXDEV because it
+# cannot cross the mount boundary. rmw must skip that WASTE and fall back to
+# the spec $topdir trash on the file's own mount.
+#
+# The whole scenario is built inside a small dedicated tmpfs ramdisk that is
+# unmounted on exit, so the test never writes to the user's home or to the
+# host /tmp tree -- only to its own throwaway mount.
+
+set -ve
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+# Creating mounts needs root; bow out cleanly when we can't sudo unattended.
+if ! sudo -n true 2>/dev/null; then
+  echo "sudo not available without password; skipping EXDEV fallback test."
+  exit "$SKIP"
+fi
+
+UID_NUM=$(id -u)
+RAM="/tmp/rmw-exdev-ram"          # dedicated tmpfs (its own device)
+BIND="$RAM/mnt"                   # second mount of $RAM/src (same device)
+WASTE_DIR="$RAM/waste/Waste"      # the only configured WASTE; on $RAM, not $BIND
+FALLBACK_TRASH="$BIND/.Trash-$UID_NUM"
+
+umount_if_mounted() {
+  if mountpoint -q "$1" 2>/dev/null; then
+    sudo umount "$1" || true
+  fi
+}
+
+# shellcheck disable=SC2329
+cleanup() {
+  cd /
+  umount_if_mounted "$BIND"       # nested mount: unmount before its parent
+  umount_if_mounted "$RAM"
+  sudo rm -rf "$RAM" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Clear any stale state left by an interrupted previous run.
+umount_if_mounted "$BIND"
+umount_if_mounted "$RAM"
+sudo rm -rf "$RAM" 2>/dev/null || true
+
+sudo mkdir -p "$RAM"
+sudo mount -t tmpfs -o size=2m tmpfs "$RAM"
+sudo chown "$UID_NUM" "$RAM"
+
+mkdir -p "$RAM/src" "$BIND" "$RAM/waste"
+sudo mount --bind "$RAM/src" "$BIND"
+sudo chown "$UID_NUM" "$BIND"
+
+# Only WASTE is on the ramdisk root: a different mount than $BIND but the same
+# device. With no WASTE on $BIND, the file can reach a trash only via the
+# $topdir fallback.
+TEST_CONFIG="$RAM/exdev.testrc"
+printf 'WASTE = %s\nexpire_age = 90\n' "$WASTE_DIR" > "$TEST_CONFIG"
+
+echo "test data" > "$BIND/foo"
+
+# The file and the configured WASTE share a device ...
+test "$(stat -c %d "$BIND/foo")" = "$(stat -c %d "$RAM")"
+# ... yet $BIND is a distinct (bind) mount, so renaming from it to a WASTE on
+# $RAM crosses a mount boundary and rename(2) returns EXDEV. (stat's %m can't
+# see bind mounts; mountpoint reads the real mount table and can.)
+mountpoint -q "$BIND"
+
+"$BIN_DIR"/rmw -c "$TEST_CONFIG" -v "$BIND/foo"
+
+# Gone from its origin ...
+test ! -e "$BIND/foo"
+# ... did NOT land in the cross-mount WASTE ...
+test ! -e "$WASTE_DIR/files/foo"
+# ... and DID land in the $topdir fallback trash on its own mount.
+test -f "$FALLBACK_TRASH/files/foo"
+test -f "$FALLBACK_TRASH/info/foo.trashinfo"
+
+echo "PASS: EXDEV bind-mount file fell back to its own-mount topdir trash"
+exit 0

--- a/test/test_exdev_fallback.sh
+++ b/test/test_exdev_fallback.sh
@@ -1,15 +1,23 @@
 #!/bin/sh
-# Regression test for the same-device / different-mount (EXDEV) fallback.
+# Same-device / different-mount (EXDEV) behavior, exercised on a small
+# dedicated tmpfs ramdisk holding a bind mount.
 #
 # A bind mount shares the underlying filesystem with its source, so a file on
 # the bind mount has the SAME st_dev as a WASTE folder elsewhere on that
 # filesystem (rmw matches it by device) yet rename(2) returns EXDEV because it
-# cannot cross the mount boundary. rmw must skip that WASTE and fall back to
-# the spec $topdir trash on the file's own mount.
+# cannot cross the mount boundary.
 #
-# The whole scenario is built inside a small dedicated tmpfs ramdisk that is
-# unmounted on exit, so the test never writes to the user's home or to the
-# host /tmp tree -- only to its own throwaway mount.
+# Covered here:
+#   1. tmpfs is an excluded filesystem, so with no reachable WASTE rmw must
+#      refuse (like desktop file managers do in /tmp) instead of creating a
+#      $topdir trash there.
+#   2. A configured WASTE on the file's own mount receives the file after the
+#      cross-mount WASTE is skipped on EXDEV.
+#   3. A pre-existing trash dir on an excluded filesystem is still honored:
+#      discovery lists it and removals can reach it.
+#
+# Everything lives inside the ramdisk, which is unmounted on exit; the test
+# never writes to the user's home or the host /tmp tree.
 
 set -ve
 
@@ -29,7 +37,7 @@ UID_NUM=$(id -u)
 RAM="/tmp/rmw-exdev-ram"          # dedicated tmpfs (its own device)
 BIND="$RAM/mnt"                   # second mount of $RAM/src (same device)
 WASTE_DIR="$RAM/waste/Waste"      # the only configured WASTE; on $RAM, not $BIND
-FALLBACK_TRASH="$BIND/.Trash-$UID_NUM"
+BIND_TRASH="$BIND/.Trash-$UID_NUM"
 
 umount_if_mounted() {
   if mountpoint -q "$1" 2>/dev/null; then
@@ -59,9 +67,6 @@ mkdir -p "$RAM/src" "$BIND" "$RAM/waste"
 sudo mount --bind "$RAM/src" "$BIND"
 sudo chown "$UID_NUM" "$BIND"
 
-# Only WASTE is on the ramdisk root: a different mount than $BIND but the same
-# device. With no WASTE on $BIND, the file can reach a trash only via the
-# $topdir fallback.
 TEST_CONFIG="$RAM/exdev.testrc"
 printf 'WASTE = %s\nexpire_age = 90\n' "$WASTE_DIR" > "$TEST_CONFIG"
 
@@ -74,15 +79,57 @@ test "$(stat -c %d "$BIND/foo")" = "$(stat -c %d "$RAM")"
 # see bind mounts; mountpoint reads the real mount table and can.)
 mountpoint -q "$BIND"
 
+# --- 1: excluded fs, no reachable WASTE -> refuse, don't create a trash ---
+out=$("$BIN_DIR"/rmw -c "$TEST_CONFIG" -v "$BIND/foo" 2>&1) || true
+echo "$out"
+cmp_substr "$out" "No WASTE folder defined"
+# The file stays put and no trash dir was created on the excluded fs.
+test -f "$BIND/foo"
+test ! -e "$BIND_TRASH"
+test ! -e "$WASTE_DIR/files/foo"
+
+echo "PASS: excluded fs with no reachable WASTE refused cleanly"
+
+# --- 2: a configured WASTE on the bind mount takes the EXDEV skip ---
+WASTE_ON_BIND="$BIND/Waste2"
+printf 'WASTE = %s\nWASTE = %s\nexpire_age = 90\n' \
+  "$WASTE_DIR" "$WASTE_ON_BIND" > "$TEST_CONFIG"
+
 "$BIN_DIR"/rmw -c "$TEST_CONFIG" -v "$BIND/foo"
 
-# Gone from its origin ...
 test ! -e "$BIND/foo"
-# ... did NOT land in the cross-mount WASTE ...
+# Not in the skipped cross-mount WASTE ...
 test ! -e "$WASTE_DIR/files/foo"
-# ... and DID land in the $topdir fallback trash on its own mount.
-test -f "$FALLBACK_TRASH/files/foo"
-test -f "$FALLBACK_TRASH/info/foo.trashinfo"
+# ... but in the configured WASTE on the file's own mount.
+test -f "$WASTE_ON_BIND/files/foo"
+test -f "$WASTE_ON_BIND/info/foo.trashinfo"
 
-echo "PASS: EXDEV bind-mount file fell back to its own-mount topdir trash"
+echo "PASS: EXDEV skip reached the configured same-mount WASTE"
+
+# --- 3: a pre-existing trash on an excluded fs is honored ---
+# Plant a spec-shaped trash dir on the bind mount, return to the single
+# cross-mount WASTE config, and verify discovery picks the planted trash up:
+# it appears in -l output and a removal lands in it after the EXDEV skip.
+#
+# Discovery is disabled under RMW_FAKE_HOME (it would see the host's real
+# mounts), so run rmw with it unset; HOME still points at the fake home, so
+# everything else stays isolated. Discovery will list host topdir trashes
+# too — the assertions are additive, and a host trash can never device-match
+# a file on this private tmpfs, so removals can't escape the ramdisk.
+mkdir -p "$BIND_TRASH/files" "$BIND_TRASH/info"
+printf 'WASTE = %s\nexpire_age = 90\n' "$WASTE_DIR" > "$TEST_CONFIG"
+
+out=$(env -u RMW_FAKE_HOME "$BIN_DIR"/rmw -c "$TEST_CONFIG" -l 2>&1)
+echo "$out"
+cmp_substr "$out" "$BIND_TRASH"
+
+echo "test data" > "$BIND/foo3"
+env -u RMW_FAKE_HOME "$BIN_DIR"/rmw -c "$TEST_CONFIG" -v "$BIND/foo3"
+
+test ! -e "$BIND/foo3"
+test ! -e "$WASTE_DIR/files/foo3"
+test -f "$BIND_TRASH/files/foo3"
+test -f "$BIND_TRASH/info/foo3.trashinfo"
+
+echo "PASS: pre-existing trash on an excluded fs was discovered and used"
 exit 0

--- a/test/test_exdev_fallback.sh
+++ b/test/test_exdev_fallback.sh
@@ -111,20 +111,19 @@ echo "PASS: EXDEV skip reached the configured same-mount WASTE"
 # cross-mount WASTE config, and verify discovery picks the planted trash up:
 # it appears in -l output and a removal lands in it after the EXDEV skip.
 #
-# Discovery is disabled under RMW_FAKE_HOME (it would see the host's real
-# mounts), so run rmw with it unset; HOME still points at the fake home, so
-# everything else stays isolated. Discovery will list host topdir trashes
-# too — the assertions are additive, and a host trash can never device-match
-# a file on this private tmpfs, so removals can't escape the ramdisk.
+# Discovery is suppressed under RMW_FAKE_HOME (it would see the host's real
+# mounts), so opt in with RMW_CHECK_DISCOVERY. Discovery will list host topdir
+# trashes too — the assertions are additive, and a host trash can never
+# device-match a file on this private tmpfs, so removals can't escape it.
 mkdir -p "$BIND_TRASH/files" "$BIND_TRASH/info"
 printf 'WASTE = %s\nexpire_age = 90\n' "$WASTE_DIR" > "$TEST_CONFIG"
 
-out=$(env -u RMW_FAKE_HOME "$BIN_DIR"/rmw -c "$TEST_CONFIG" -l 2>&1)
+out=$(RMW_CHECK_DISCOVERY=1 "$BIN_DIR"/rmw -c "$TEST_CONFIG" -l 2>&1)
 echo "$out"
 cmp_substr "$out" "$BIND_TRASH"
 
 echo "test data" > "$BIND/foo3"
-env -u RMW_FAKE_HOME "$BIN_DIR"/rmw -c "$TEST_CONFIG" -v "$BIND/foo3"
+RMW_CHECK_DISCOVERY=1 "$BIN_DIR"/rmw -c "$TEST_CONFIG" -v "$BIND/foo3"
 
 test ! -e "$BIND/foo3"
 test ! -e "$WASTE_DIR/files/foo3"

--- a/test/test_file_bind_mount.sh
+++ b/test/test_file_bind_mount.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Regression test: discovery must skip mount points that are files, not
+# directories. Containers (Docker) and some systemd setups bind-mount single
+# files like /etc/resolv.conf; before the fix, discovery probed "<file>/.Trash"
+# and printed ":error: lstat ...: Not a directory" for each one.
+#
+# Built inside an unprivileged mount namespace (no sudo). RMW_CHECK_DISCOVERY
+# re-enables discovery under RMW_FAKE_HOME so it enumerates our file mount.
+
+set -ve
+
+# Re-exec inside a private mount namespace (mapped to root so mount works)
+# before sourcing COMMON. Skip (77) if unprivileged userns is unavailable.
+if [ -z "$RMW_FILEMNT_NS" ]; then
+  if ! unshare --mount --map-root-user true 2>/dev/null; then
+    echo "unprivileged mount namespace unavailable; skipping file-mount test."
+    exit 77
+  fi
+  RMW_FILEMNT_NS=1 exec unshare --mount --map-root-user "$0" "$@"
+fi
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+ROOT="/tmp/rmw-filemnt"
+SRC="$ROOT/source_file"
+MNT="$ROOT/etcfile"            # a regular file used as a bind-mount target
+rm -rf "$ROOT"
+mkdir -p "$ROOT"
+echo src > "$SRC"
+# Make it executable so the file mount passes rmw's access(R_OK|X_OK) mount
+# filter and reaches the directory probe -- without sudo we can only make a
+# tmpfs mount here, which rmw treats as an excluded fs; on a real disk (the
+# Docker /etc/resolv.conf case) an eligible file mount reaches the same probe.
+chmod 0755 "$SRC"
+: > "$MNT"
+mount --bind "$SRC" "$MNT"     # $MNT is now a *file* mount point
+mountpoint -q "$MNT"           # sanity: it really is a mount
+
+CONFIG="$RMW_FAKE_HOME/filemnt.rc"
+mkdir -p "$RMW_FAKE_HOME"
+printf 'expire_age = 30\n' > "$CONFIG"
+
+cd "$RMW_FAKE_HOME"
+
+# -l forces discovery to enumerate every mount, including the file mount.
+out=$(RMW_CHECK_DISCOVERY=1 "$BIN_DIR"/rmw -c "$CONFIG" -l 2>&1)
+echo "$out"
+
+# The file mount must be skipped silently: no error, and its path must not
+# appear in any "<path>/.Trash" probe.
+if cmp_substr "$out" "Not a directory"; then
+  echo "FAIL: discovery errored on a file bind-mount"
+  exit 1
+fi
+if cmp_substr "$out" "$MNT"; then
+  echo "FAIL: a file bind-mount must not appear in discovery output"
+  exit 1
+fi
+
+# And normal operation still works with the file mount present.
+echo data > victim
+RMW_CHECK_DISCOVERY=1 "$BIN_DIR"/rmw -c "$CONFIG" victim
+test ! -e victim
+test -f "$RMW_FAKE_HOME/.local/share/Trash/files/victim"
+
+echo "PASS: file bind-mount skipped by discovery; removal unaffected"
+exit 0

--- a/test/test_media_root_space.sh
+++ b/test/test_media_root_space.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Regression test: a top-level (media_root) waste folder whose mount path
+# contains a space must produce a correct relative Path= in the .trashinfo,
+# not a corrupt one or a crash. Before the fix, create_trashinfo() stripped
+# media_root from the percent-ESCAPED path by raw byte length, so a space
+# (escaped to %20) desynced the offset and aborted via diag_fatal.
+#
+# Built inside an unprivileged mount namespace (no sudo): a tmpfs mounted at
+# a path containing a space, with a WASTE folder at its top level so
+# media_root is set. The mount vanishes when the namespace exits.
+
+set -ve
+
+if [ -z "$RMW_MRSPACE_NS" ]; then
+  if ! unshare --mount --map-root-user true 2>/dev/null; then
+    echo "unprivileged mount namespace unavailable; skipping."
+    exit 77
+  fi
+  RMW_MRSPACE_NS=1 exec unshare --mount --map-root-user "$0" "$@"
+fi
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+MNT="/tmp/rmw mr space"          # mount path with a space
+WASTE="$MNT/.Trash-$(id -u)"     # top-level waste -> media_root gets set
+rm -rf "$MNT"
+mkdir -p "$MNT"
+mount -t tmpfs none "$MNT"
+
+CONFIG="$RMW_FAKE_HOME/mrspace.rc"
+mkdir -p "$RMW_FAKE_HOME"
+printf 'WASTE = %s\nexpire_age = 30\n' "$WASTE" > "$CONFIG"
+
+echo data > "$MNT/victim"
+
+# Must not crash; the file must land in the spaced-path waste.
+"$BIN_DIR"/rmw -c "$CONFIG" "$MNT/victim"
+test ! -e "$MNT/victim"
+test -f "$WASTE/files/victim"
+test -f "$WASTE/info/victim.trashinfo"
+
+# Path= must be the correct *relative* path (no leading '/', no %20 mangling).
+path_line=$(grep '^Path=' "$WASTE/info/victim.trashinfo")
+echo "$path_line"
+test "$path_line" = "Path=victim"
+
+echo "PASS: spaced media_root produced a correct relative Path="
+exit 0

--- a/test/test_topdir_trash.c
+++ b/test/test_topdir_trash.c
@@ -1,0 +1,97 @@
+/*
+This file is part of rmw<https://theimpossibleastronaut.github.io/rmw-website/>
+
+Copyright (C) 2012-2026  Andy Alt (arch_stanton5995@proton.me)
+Other authors: https://github.com/theimpossibleastronaut/rmw/blob/master/AUTHORS.md
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* Include the full translation unit to access trash_path_for_topdir (static). */
+#include "../src/topdir_trash.c"
+
+#include "test.h"
+#include "purging.h"
+
+
+static void
+test_trash_path_for_topdir(const char *tmpdir, const char *uid)
+{
+  char expected[PATH_MAX];
+
+  /* no .Trash dir → .Trash-$uid */
+  {
+    char *result = trash_path_for_topdir(tmpdir, uid);
+    sn_check(snprintf(expected, sizeof expected, "%s/.Trash-%s", tmpdir, uid),
+             sizeof expected);
+    assert(result != NULL);
+    assert(strcmp(result, expected) == 0);
+    free(result);
+  }
+
+  char dot_trash[PATH_MAX];
+  sn_check(snprintf(dot_trash, sizeof dot_trash, "%s/.Trash", tmpdir),
+           sizeof dot_trash);
+
+  /* .Trash is a symlink → .Trash-$uid */
+  {
+    assert(symlink(tmpdir, dot_trash) == 0);
+    char *result = trash_path_for_topdir(tmpdir, uid);
+    sn_check(snprintf(expected, sizeof expected, "%s/.Trash-%s", tmpdir, uid),
+             sizeof expected);
+    assert(result != NULL);
+    assert(strcmp(result, expected) == 0);
+    free(result);
+    assert(remove(dot_trash) == 0);
+  }
+
+  /* .Trash without sticky bit → .Trash-$uid */
+  {
+    assert(mkdir(dot_trash, 0755) == 0);
+    char *result = trash_path_for_topdir(tmpdir, uid);
+    sn_check(snprintf(expected, sizeof expected, "%s/.Trash-%s", tmpdir, uid),
+             sizeof expected);
+    assert(result != NULL);
+    assert(strcmp(result, expected) == 0);
+    free(result);
+    assert(rmdir(dot_trash) == 0);
+  }
+
+  /* .Trash with sticky bit, not a symlink → .Trash/$uid */
+  {
+    assert(mkdir(dot_trash, 01755) == 0);
+    char *result = trash_path_for_topdir(tmpdir, uid);
+    sn_check(snprintf(expected, sizeof expected, "%s/.Trash/%s", tmpdir, uid),
+             sizeof expected);
+    assert(result != NULL);
+    assert(strcmp(result, expected) == 0);
+    free(result);
+    assert(rmdir(dot_trash) == 0);
+  }
+}
+
+
+int
+main(void)
+{
+  char tmpdir[PATH_MAX];
+  sn_check(snprintf(tmpdir, sizeof tmpdir, "%s/test_topdir_trash",
+                    RMW_FAKE_HOME), sizeof tmpdir);
+  assert(rmw_mkdir(tmpdir) == 0);
+
+  test_trash_path_for_topdir(tmpdir, "1000");
+
+  assert(bsdutils_rm(tmpdir, false) == 0);
+  return 0;
+}

--- a/test/test_topdir_trash.c
+++ b/test/test_topdir_trash.c
@@ -70,7 +70,8 @@ test_trash_path_for_topdir(const char *tmpdir, const char *uid)
 
   /* .Trash with sticky bit, not a symlink → .Trash/$uid */
   {
-    assert(mkdir(dot_trash, 01755) == 0);
+    assert(mkdir(dot_trash, 0755) == 0);
+    assert(chmod(dot_trash, 01755) == 0); /* mkdir strips sticky bit on macOS */
     char *result = trash_path_for_topdir(tmpdir, uid);
     sn_check(snprintf(expected, sizeof expected, "%s/.Trash/%s", tmpdir, uid),
              sizeof expected);

--- a/test/test_topdir_trash.c
+++ b/test/test_topdir_trash.c
@@ -95,6 +95,7 @@ test_fs_type_is_eligible(void)
   assert(fs_type_is_eligible("cgroup2") == false);
   assert(fs_type_is_eligible("overlay") == false);
   assert(fs_type_is_eligible("squashfs") == false);
+  assert(fs_type_is_eligible("efivarfs") == false);
 
   /* network shares the spec leaves undefined */
   assert(fs_type_is_eligible("cifs") == false);

--- a/test/test_topdir_trash.c
+++ b/test/test_topdir_trash.c
@@ -83,6 +83,86 @@ test_trash_path_for_topdir(const char *tmpdir, const char *uid)
 }
 
 
+static void
+test_fs_type_is_eligible(void)
+{
+  assert(fs_type_is_eligible(NULL) == false);
+
+  /* pseudo / system fs */
+  assert(fs_type_is_eligible("proc") == false);
+  assert(fs_type_is_eligible("sysfs") == false);
+  assert(fs_type_is_eligible("tmpfs") == false);
+  assert(fs_type_is_eligible("cgroup2") == false);
+  assert(fs_type_is_eligible("overlay") == false);
+  assert(fs_type_is_eligible("squashfs") == false);
+
+  /* network shares the spec leaves undefined */
+  assert(fs_type_is_eligible("cifs") == false);
+  assert(fs_type_is_eligible("smbfs") == false);
+  assert(fs_type_is_eligible("smb3") == false);
+
+  /* fuse.* prefix → excluded */
+  assert(fs_type_is_eligible("fuse.sshfs") == false);
+  assert(fs_type_is_eligible("fuse.rclone") == false);
+  assert(fs_type_is_eligible("fuse.gvfsd-fuse") == false);
+
+  /* eligible: real on-disk filesystems and nfs */
+  assert(fs_type_is_eligible("ext4") == true);
+  assert(fs_type_is_eligible("btrfs") == true);
+  assert(fs_type_is_eligible("xfs") == true);
+  assert(fs_type_is_eligible("bcachefs") == true);
+  assert(fs_type_is_eligible("vfat") == true);
+  assert(fs_type_is_eligible("ntfs") == true);
+  assert(fs_type_is_eligible("nfs") == true);
+  assert(fs_type_is_eligible("nfs4") == true);
+}
+
+
+static void
+test_build_mount_trash_list(const char *tmpdir, const char *uid)
+{
+  char home_trash[PATH_MAX];
+  sn_check(snprintf(home_trash, sizeof home_trash, "%s/Trash", tmpdir),
+           sizeof home_trash);
+
+  struct stat st;
+  assert(lstat(tmpdir, &st) == 0);
+  dev_t home_dev = st.st_dev;
+
+  st_mount_trash *head = build_mount_trash_list(uid, home_trash, home_dev);
+  assert(head != NULL);
+
+  /* Head is the home-trash node. */
+  assert(head->is_home_trash == true);
+  assert(head->mount_path == NULL);
+  assert(strcmp(head->trash_dir, home_trash) == 0);
+  assert(head->dev_num == home_dev);
+
+  char expected_files[PATH_MAX];
+  char expected_info[PATH_MAX];
+  sn_check(snprintf(expected_files, sizeof expected_files, "%s/files",
+                    home_trash), sizeof expected_files);
+  sn_check(snprintf(expected_info, sizeof expected_info, "%s/info",
+                    home_trash), sizeof expected_info);
+  assert(strcmp(head->files_dir, expected_files) == 0);
+  assert(strcmp(head->info_dir, expected_info) == 0);
+
+  /* No subsequent node should duplicate the home volume, and none should
+   * be flagged as the home trash. */
+  for (st_mount_trash *n = head->next; n != NULL; n = n->next)
+  {
+    assert(n->is_home_trash == false);
+    assert(n->mount_path != NULL);
+    assert(n->trash_dir != NULL);
+    assert(n->files_dir != NULL);
+    assert(n->info_dir != NULL);
+    assert(n->dev_num != home_dev);
+  }
+
+  free_mount_trash_list(head);
+}
+
+
 int
 main(void)
 {
@@ -92,6 +172,8 @@ main(void)
   assert(rmw_mkdir(tmpdir) == 0);
 
   test_trash_path_for_topdir(tmpdir, "1000");
+  test_fs_type_is_eligible();
+  test_build_mount_trash_list(tmpdir, "1000");
 
   assert(bsdutils_rm(tmpdir, false) == 0);
   return 0;

--- a/test/test_waste_negation.sh
+++ b/test/test_waste_negation.sh
@@ -41,11 +41,20 @@ test ! -e newfile
 test -f "$WASTE_OK/files/newfile"
 test ! -e "$WASTE_NEG/files/newfile"
 
-# --- -l lists the negated folder, marked with the config's '!' syntax ---
+# --- plain -l stays a bare, pipeable list of paths ---
 out=$($RMW -l)
 echo "$out"
-cmp_substr "$out" "!$WASTE_NEG"
+cmp_substr "$out" "$WASTE_NEG"
 cmp_substr "$out" "$WASTE_OK"
+if cmp_substr "$out" "!$WASTE_NEG"; then
+  echo "FAIL: '!' marker must not appear in the bare -l list"
+  exit 1
+fi
+
+# --- with -v, the negated folder is marked with the config's '!' syntax ---
+outv=$($RMW -l -v)
+echo "$outv"
+cmp_substr "$outv" "!$WASTE_NEG"
 
 # --- restore from the negated folder works ---
 $RMW -z "$WASTE_NEG/files/restoreme"

--- a/test/test_waste_negation.sh
+++ b/test/test_waste_negation.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# "!WASTE = /path" marks a waste folder that never receives files when
-# removing, but still participates in listing, restoring, and purging.
+# The "no-add" attribute (WASTE = /path, no-add) marks a waste folder that
+# never receives files when removing, but still participates in listing,
+# restoring, and purging.
 
 set -ve
 
@@ -15,7 +16,7 @@ WASTE_OK="$RMW_FAKE_HOME/.Waste"
 TEST_CONFIG="$RMW_FAKE_HOME/negation.testrc"
 
 mkdir -p "$RMW_FAKE_HOME"
-printf '!WASTE = %s\nWASTE = %s\nexpire_age = 1\n' \
+printf 'WASTE = %s, no-add\nWASTE = %s\nexpire_age = 1\n' \
   "$WASTE_NEG" "$WASTE_OK" > "$TEST_CONFIG"
 RMW="$BIN_DIR/rmw -c $TEST_CONFIG"
 
@@ -41,20 +42,20 @@ test ! -e newfile
 test -f "$WASTE_OK/files/newfile"
 test ! -e "$WASTE_NEG/files/newfile"
 
-# --- plain -l stays a bare, pipeable list of paths ---
+# --- plain -l stays a bare, pipeable list of paths (no annotations) ---
 out=$($RMW -l)
 echo "$out"
 cmp_substr "$out" "$WASTE_NEG"
 cmp_substr "$out" "$WASTE_OK"
-if cmp_substr "$out" "!$WASTE_NEG"; then
-  echo "FAIL: '!' marker must not appear in the bare -l list"
+if cmp_substr "$out" "no-add"; then
+  echo "FAIL: annotations must not appear in the bare -l list"
   exit 1
 fi
 
-# --- with -v, the negated folder is marked with the config's '!' syntax ---
+# --- with -v, the folder carries a (no-add) annotation ---
 outv=$($RMW -l -v)
 echo "$outv"
-cmp_substr "$outv" "!$WASTE_NEG"
+cmp_substr "$outv" "no-add"
 
 # --- restore from the negated folder works ---
 $RMW -z "$WASTE_NEG/files/restoreme"
@@ -69,5 +70,5 @@ test ! -e "$WASTE_NEG/info/purgeme.trashinfo"
 # the file just removed today is not expired and must survive the purge
 test -f "$WASTE_OK/files/newfile"
 
-echo "PASS: !WASTE folder skipped for removals, honored for list/restore/purge"
+echo "PASS: no-add folder skipped for removals, honored for list/restore/purge"
 exit 0

--- a/test/test_waste_negation.sh
+++ b/test/test_waste_negation.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# "!WASTE = /path" marks a waste folder that never receives files when
+# removing, but still participates in listing, restoring, and purging.
+
+set -ve
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+WASTE_NEG="$RMW_FAKE_HOME/.WasteNeg"
+WASTE_OK="$RMW_FAKE_HOME/.Waste"
+TEST_CONFIG="$RMW_FAKE_HOME/negation.testrc"
+
+mkdir -p "$RMW_FAKE_HOME"
+printf '!WASTE = %s\nWASTE = %s\nexpire_age = 1\n' \
+  "$WASTE_NEG" "$WASTE_OK" > "$TEST_CONFIG"
+RMW="$BIN_DIR/rmw -c $TEST_CONFIG"
+
+# Plant two items in the negated folder: one to restore, one (long expired)
+# to purge.
+mkdir -p "$WASTE_NEG/files" "$WASTE_NEG/info"
+echo old > "$WASTE_NEG/files/purgeme"
+echo old > "$WASTE_NEG/files/restoreme"
+for f in purgeme restoreme; do
+  cat > "$WASTE_NEG/info/$f.trashinfo" << TRASHINFO
+[Trash Info]
+Path=$RMW_FAKE_HOME/$f
+DeletionDate=2020-01-01T00:00:00
+TRASHINFO
+done
+
+cd "$RMW_FAKE_HOME"
+
+# --- removals skip the negated folder, even listed first on the same fs ---
+touch newfile
+$RMW newfile
+test ! -e newfile
+test -f "$WASTE_OK/files/newfile"
+test ! -e "$WASTE_NEG/files/newfile"
+
+# --- -l lists the negated folder, marked with the config's '!' syntax ---
+out=$($RMW -l)
+echo "$out"
+cmp_substr "$out" "!$WASTE_NEG"
+cmp_substr "$out" "$WASTE_OK"
+
+# --- restore from the negated folder works ---
+$RMW -z "$WASTE_NEG/files/restoreme"
+test -f "$RMW_FAKE_HOME/restoreme"
+test ! -e "$WASTE_NEG/files/restoreme"
+test ! -e "$WASTE_NEG/info/restoreme.trashinfo"
+
+# --- purge reaches into the negated folder ---
+$RMW -g
+test ! -e "$WASTE_NEG/files/purgeme"
+test ! -e "$WASTE_NEG/info/purgeme.trashinfo"
+# the file just removed today is not expired and must survive the purge
+test -f "$WASTE_OK/files/newfile"
+
+echo "PASS: !WASTE folder skipped for removals, honored for list/restore/purge"
+exit 0


### PR DESCRIPTION
Add find_topdir_trash() which uses g_unix_mount_for() (gio-unix-2.0) to locate the mount point for a file, then returns the spec-compliant trash path: $topdir/.Trash/$uid if .Trash is a valid sticky non-symlink directory, otherwise $topdir/.Trash-$uid.

Unit test lives in a separate file (test/test_topdir_trash.c) which includes the source to access the static trash_path_for_topdir().

Bump GLib/GIO minimum from 2.50 to 2.52 for g_unix_mount_for().

For #525 