### PR TITLE
Rename build option "want_ficlone" to "with-reflink"

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -19,6 +19,7 @@ entrypoint
 env
 env
 filesystem
+fs
 FreeDesktop
 gettext
 gpl

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -1,8 +1,10 @@
 AppImages
 bli
 BSDCoreUtils
+bcachefs
 bsdutils
 btrfs
+reflink
 builddir
 CentOS
 cli
@@ -12,6 +14,7 @@ devel
 Dnls
 Dprefix
 Dwant
+Dwith
 entrypoint
 env
 env

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,8 +4,8 @@ rmw (in-progress):
     and bcachefs subvolumes (requires glib2 >= 2.50); replace several
     internal utility functions with GLib equivalents
   * BREAKING: The meson build option `want_btrfs_clone` has been renamed to
-    `want_ficlone`. Update any build scripts that pass `-Dwant_btrfs_clone=`
-    to use `-Dwant_ficlone=` instead.
+    `with-reflink`. Update any build scripts that pass `-Dwant_btrfs_clone=`
+    to use `-Dwith-reflink=` instead.
   * ficlone: Add bcachefs filesystem detection; directories containing
     special files (FIFOs, sockets, devices) now fail gracefully instead
     of hanging; fix missing errno propagation on early failures; preserve

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ just the ncurses packages is needed, and it's often already installed.
 * linux-headers
 
 `linux/fs.h` from the headers package is required for btrfs/bcachefs
-reflink support.  `meson setup` will fail if the header is missing. To
+[reflink](https://www.rubdos.be/2017/07/30/about-reflinks.html) support.  `meson setup` will fail if the header is missing. To
 bypass the check and exclude support (which is only necessary
 if you want `rmw` to be able to move files between subvolumes) add
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,12 @@ just the ncurses packages is needed, and it's often already installed.
 
 * linux-headers
 
-`linux/btrfs.h` from the headers package is required for btrfs clone support.
-`meson setup` will fail if the header is missing. To bypass the check and
-exclude support for for btrfs (which is not needed for btrfs normally, but
-needed if you want to use `rmw` for rmw'ing files across btrfs root and
-subvolumes), add
+`linux/fs.h` from the headers package is required for btrfs/bcachefs
+reflink support.  `meson setup` will fail if the header is missing. To
+bypass the check and exclude support (which is only necessary
+if you want `rmw` to be able to move files between subvolumes) add
 
-    -Dwant_btrfs_clone=false
+    -Dwant_ficlone_clone=false
 
 to the meson setup options.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ just the ncurses packages is needed, and it's often already installed.
 bypass the check and exclude support (which is only necessary
 if you want `rmw` to be able to move files between subvolumes) add
 
-    -Dwant_ficlone_clone=false
+    -Dwith-reflink=false
 
 to the meson setup options.
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 option('build_tests', type : 'boolean', value : true,
        description : 'build tests')
 option(
-    'want_ficlone',
+    'with-reflink',
     type : 'boolean',
     value: 'true',
     description: 'Include support for cloning files between subvolumes using FICLONE (btrfs, bcachefs, xfs, etc.)')

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,7 +39,7 @@ src = [
 has_statfs = false
 has_linux_fs_header = false
 if host_sys == 'linux'
-  if get_option('want_ficlone')
+  if get_option('with-reflink')
     has_statfs = cc.has_function(
       'statfs',
       prefix: '#include <sys/statfs.h>',
@@ -54,7 +54,7 @@ if host_sys == 'linux'
   : Requirements not met for reflink clone support.
   : If missing linux/fs.h, you probably need to install the linux-headers package.
   : To build without reflink clone support and skip this check, add
-  : "-Dwant_ficlone=false" to the meson setup options.''',
+  : "-Dwith-reflink=false" to the meson setup options.''',
       )
     endif
   endif


### PR DESCRIPTION
Just a minor update.

It strikes me that `ficlone` is not a common user-space term. It would perhaps make sense to rename `want_ficlone_clone` to something like `reflink_support`.