### PR TITLE
Add diag/diag_fatal/verbose_printf helpers and migrate callers

### DIFF
--- a/src/ficlone.c
+++ b/src/ficlone.c
@@ -55,7 +55,7 @@ is_ficlone_fs(const char *path)
   int r = statfs(dir, &buf);
   if (r == -1)
   {
-    fprintf(stderr, "statfs '%s': %s\n", dir, strerror(errno));
+    diag(DIAG_WARN, "statfs '%s': %s\n", dir, strerror(errno));
     g_free(dir);
     return false;
   }
@@ -81,14 +81,16 @@ do_ficlone(const char *source, const char *dest)
   src_fd = open(source, O_RDONLY);
   if (src_fd == -1)
   {
-    perror("open source");
+    err = errno;
+    diag(DIAG_ERR, "open source: %s\n", strerror(err));
+    errno = err;
     return -1;
   }
 
   if (fstat(src_fd, &src_stat) == -1)
   {
     err = errno;
-    perror("fstat source");
+    diag(DIAG_ERR, "fstat source: %s\n", strerror(err));
     close(src_fd);
     errno = err;
     return -1;
@@ -100,7 +102,7 @@ do_ficlone(const char *source, const char *dest)
   if (dest_fd == -1)
   {
     err = errno;
-    perror("open destination");
+    diag(DIAG_ERR, "open destination: %s\n", strerror(err));
     close(src_fd);
     errno = err;
     return -1;
@@ -113,9 +115,9 @@ do_ficlone(const char *source, const char *dest)
   {
     struct timespec times[2] = { src_stat.st_atim, src_stat.st_mtim };
     if (futimens(dest_fd, times) == -1)
-      perror("futimens");
+      diag(DIAG_ERR, "futimens: %s\n", strerror(errno));
     if (fchown(dest_fd, src_stat.st_uid, src_stat.st_gid) == -1)
-      perror("fchown");
+      diag(DIAG_ERR, "fchown: %s\n", strerror(errno));
 
     ssize_t names_len = flistxattr(src_fd, NULL, 0);
     if (names_len > 0)
@@ -133,8 +135,8 @@ do_ficlone(const char *source, const char *dest)
           if (val_len == 0)
           {
             if (fsetxattr(dest_fd, name, "", 0, 0) == -1)
-              fprintf(stderr, "fsetxattr '%s' on '%s': %s\n",
-                      name, dest, strerror(errno));
+              diag(DIAG_WARN, "fsetxattr '%s' on '%s': %s\n",
+                   name, dest, strerror(errno));
             continue;
           }
           char *val = malloc(val_len);
@@ -143,8 +145,8 @@ do_ficlone(const char *source, const char *dest)
           if (fgetxattr(src_fd, name, val, val_len) == val_len)
           {
             if (fsetxattr(dest_fd, name, val, val_len, 0) == -1)
-              fprintf(stderr, "fsetxattr '%s' on '%s': %s\n",
-                      name, dest, strerror(errno));
+              diag(DIAG_WARN, "fsetxattr '%s' on '%s': %s\n",
+                   name, dest, strerror(errno));
           }
           free(val);
         }
@@ -159,9 +161,9 @@ do_ficlone(const char *source, const char *dest)
   if (res == -1)
   {
     if (err != EXDEV)
-      fprintf(stderr, "ioctl: %s in %s\n", strerror(err), __func__);
+      diag(DIAG_ERR, "ioctl: %s in %s\n", strerror(err), __func__);
     if (unlink(dest) != 0)
-      fprintf(stderr, "unlink: %s in %s\n", strerror(errno), __func__);
+      diag(DIAG_ERR, "unlink: %s in %s\n", strerror(errno), __func__);
     errno = err;
     return -1;
   }
@@ -169,11 +171,11 @@ do_ficlone(const char *source, const char *dest)
   if (unlink(source) == -1)
   {
     err = errno;
-    perror("unlink source");
+    diag(DIAG_ERR, "unlink source: %s\n", strerror(err));
     /* dest is a valid clone but source couldn't be removed; clean up dest
        so the caller can retry rather than leaving an orphan in the waste folder */
     if (unlink(dest) != 0)
-      fprintf(stderr, "unlink: %s in %s\n", strerror(errno), __func__);
+      diag(DIAG_ERR, "unlink: %s in %s\n", strerror(errno), __func__);
     errno = err;
     return -1;
   }
@@ -219,7 +221,7 @@ do_ficlone_dir(const char *src, const char *dst)
     struct stat st;
     if (fstatat(dirfd(dir), entry->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0)
     {
-      fprintf(stderr, "fstatat '%s': %s\n", src_child, strerror(errno));
+      diag(DIAG_ERR, "fstatat '%s': %s\n", src_child, strerror(errno));
       result = -1;
     }
     else
@@ -240,7 +242,7 @@ do_ficlone_dir(const char *src, const char *dst)
                      sizeof(link_target) - 1);
         if (len == -1)
         {
-          fprintf(stderr, "readlinkat '%s': %s\n", src_child, strerror(errno));
+          diag(DIAG_ERR, "readlinkat '%s': %s\n", src_child, strerror(errno));
           result = -1;
         }
         else
@@ -248,13 +250,13 @@ do_ficlone_dir(const char *src, const char *dst)
           link_target[len] = '\0';
           if (symlink(link_target, dst_child) != 0)
           {
-            fprintf(stderr, "symlink '%s': %s\n", dst_child, strerror(errno));
+            diag(DIAG_ERR, "symlink '%s': %s\n", dst_child, strerror(errno));
             result = -1;
           }
           else if (unlinkat(dirfd(dir), entry->d_name, 0) != 0)
           {
             int err = errno;
-            fprintf(stderr, "unlinkat '%s': %s\n", src_child, strerror(err));
+            diag(DIAG_ERR, "unlinkat '%s': %s\n", src_child, strerror(err));
             /* src_child is still intact; remove dst_child to avoid duplicate */
             unlink(dst_child);
             errno = err;
@@ -286,9 +288,9 @@ do_ficlone_dir(const char *src, const char *dst)
   {
     errno = saved_err;
     if (files_moved > 0)
-      fprintf(stderr,
-              _("partial move: check both '%s' and '%s' -- some files may have already been moved\n"),
-              src, dst);
+      diag(DIAG_WARN,
+           _("partial move: check both '%s' and '%s' -- some files may have already been moved\n"),
+           src, dst);
     return -1;
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -39,12 +39,8 @@ set_time_string(char *tm_str, const size_t len, const char *format,
 {
   struct tm result;
   if (localtime_r(&time_t_now, &result) == NULL)
-  {
-    fputs
-      ("Error: localtime_r() failed for time_t value beyond 32-bit limit.\n",
-       stderr);
-    exit(EXIT_FAILURE);
-  }
+    diag_fatal(EXIT_FAILURE,
+               "localtime_r() failed for time_t value beyond 32-bit limit.\n");
   strftime(tm_str, len, format, &result);
   trim_whitespace(tm_str);
 
@@ -117,15 +113,11 @@ process_mrl(st_waste *waste_head,
 
     int n_items = fread(contents, 1, f_size + 1, fp);
     if (n_items != f_size)
-    {
-      print_msg_warn();
-      fprintf(stdout, "ftell() returned %d, but fread() returned %d", f_size,
-              n_items);
-    }
+      diag(DIAG_WARN, "ftell() returned %d, but fread() returned %d", f_size,
+           n_items);
     if (feof(fp) == 0)
     {
-      print_msg_error();
-      fprintf(stderr, "while reading %s\n", mrl_file);
+      diag(DIAG_ERR, "while reading %s\n", mrl_file);
       clearerr(fp);
     }
     close_file(&fp, mrl_file, __func__);
@@ -338,8 +330,7 @@ damage of 5000 hp. You feel satisfied.\n"));
     }
     else
     {
-      print_msg_warn();
-      printf("lstat: (argv[file_arg]) %s\n", strerror(errno));
+      diag(DIAG_WARN, "lstat: (argv[file_arg]) %s\n", strerror(errno));
       continue;
     }
 
@@ -369,9 +360,9 @@ damage of 5000 hp. You feel satisfied.\n"));
           (waste_curr->parent, st_target.real_path,
            strlen(waste_curr->parent)) == 0)
       {
-        print_msg_warn();
-        printf(_("%s resides within a waste folder and has been ignored\n"),
-               argv[file_arg]);
+        diag(DIAG_WARN,
+             _("%s resides within a waste folder and has been ignored\n"),
+             argv[file_arg]);
         is_protected = 1;
         if (getenv("RMW_FAKE_HOME"))
           n_err++;
@@ -442,9 +433,8 @@ damage of 5000 hp. You feel satisfied.\n"));
 
         if (r_result == 0)
         {
-          if (verbose)
-            printf("'%s' -> '%s'\n", argv[file_arg],
-                   st_target.waste_dest_name);
+          verbose_printf(1, "'%s' -> '%s'\n", argv[file_arg],
+                         st_target.waste_dest_name);
 
           removed_files_ctr++;
 
@@ -527,12 +517,9 @@ get_locations(const char *alt_config_file)
   if (x.home_dir == NULL)
     return NULL;
 
-  if (verbose)
-  {
-    if (enable_test)
-      printf("%s:%s\n", ENV_RMW_FAKE_HOME, enable_test);
-    printf("home_dir: %s\n", x.home_dir);
-  }
+  if (enable_test)
+    verbose_printf(1, "%s:%s\n", ENV_RMW_FAKE_HOME, enable_test);
+  verbose_printf(1, "home_dir: %s\n", x.home_dir);
 
   static char s_data_dir[PATH_MAX];
   char *tmp = canfigger_data_dir(PACKAGE_STRING);
@@ -543,8 +530,7 @@ get_locations(const char *alt_config_file)
   free(tmp);
   x.data_dir = s_data_dir;
 
-  if (verbose)
-    printf("data_dir: %s\n", x.data_dir);
+  verbose_printf(1, "data_dir: %s\n", x.data_dir);
 
   char *default_config_file = canfigger_config_file("rmwrc");
   if (!default_config_file)
@@ -552,8 +538,7 @@ get_locations(const char *alt_config_file)
 
   gchar *config_dir = g_path_get_dirname(default_config_file);
 
-  if (verbose)
-    printf("config_dir: %s\n", config_dir);
+  verbose_printf(1, "config_dir: %s\n", config_dir);
 
   int p_state = check_pathname_state(config_dir);
   if (p_state == ENOENT)
@@ -585,8 +570,7 @@ get_locations(const char *alt_config_file)
 
   free(default_config_file);
 
-  if (verbose)
-    printf("config_file: %s\n", x.config_file);
+  verbose_printf(1, "config_file: %s\n", x.config_file);
 
   if ((p_state = check_pathname_state(x.config_file)) == ENOENT)
   {
@@ -626,11 +610,8 @@ get_locations(const char *alt_config_file)
   free(m_tmp_str);
   x.purge_time_file = s_purge_time_file;
 
-  if (verbose)
-  {
-    printf("mrl_file: %s\n", x.mrl_file);
-    printf("purge_time_file: %s\n", x.purge_time_file);
-  }
+  verbose_printf(1, "mrl_file: %s\n", x.mrl_file);
+  verbose_printf(1, "purge_time_file: %s\n", x.purge_time_file);
 
   return &x;
 }
@@ -654,21 +635,18 @@ main(const int argc, char *const argv[])
   init_rmw_options(&cli_user_options);
   parse_cli_options(argc, argv, &cli_user_options);
 
-  if (verbose > 1)
-    printf("PATH_MAX = %d\n", PATH_MAX);
+  verbose_printf(2, "PATH_MAX = %d\n", PATH_MAX);
 
-  if (verbose > 0)
 #ifdef HAVE_FICLONE
-    puts("ficlone support: true");
+  verbose_printf(1, "ficlone support: true\n");
 #else
-    puts("ficlone support: false");
+  verbose_printf(1, "ficlone support: false\n");
 #endif
 
   const st_loc *st_location = get_locations(cli_user_options.alt_config_file);
   if (st_location == NULL)
   {
-    print_msg_error();
-    fputs(_("while getting the path to your home directory\n"), stderr);
+    diag(DIAG_ERR, "%s", _("while getting the path to your home directory\n"));
     return 1;
   }
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -20,6 +20,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "messages.h"
 
+#include <stdarg.h>
+
+void
+diag(diag_level level, const char *fmt, ...)
+{
+  switch (level)
+  {
+  case DIAG_ERR:
+    fputs(_("  :error: "), stderr);
+    break;
+  case DIAG_WARN:
+    fputs(_(" :warning: "), stderr);
+    break;
+  }
+
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+}
+
+void
+diag_fatal(const int exit_code, const char *fmt, ...)
+{
+  fputs(_("  :error: "), stderr);
+
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+
+  exit(exit_code);
+}
+
 void
 print_msg_error(void)
 {
@@ -214,4 +248,16 @@ void
 msg_warn_file_not_found(const char *file)
 {
   printf("'%s': %s\n", file, strerror(ENOENT));
+}
+
+void
+verbose_printf(const int min_level, const char *fmt, ...)
+{
+  if (verbose < min_level)
+    return;
+
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stdout, fmt, args);
+  va_end(args);
 }

--- a/src/messages.h
+++ b/src/messages.h
@@ -28,6 +28,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define fatal_malloc() real_fatal_malloc(__func__, __LINE__)
 
+typedef enum
+{
+  DIAG_ERR,
+  DIAG_WARN
+} diag_level;
+
+void diag(diag_level level, const char *fmt, ...)
+  __attribute__((format(printf, 2, 3)));
+
+void diag_fatal(const int exit_code, const char *fmt, ...)
+  __attribute__((noreturn, format(printf, 2, 3)));
+
 void print_msg_error(void);
 
 void print_msg_warn(void);
@@ -59,3 +71,6 @@ void msg_err_mkdir(const char *dir, const char *func);
 void msg_success_mkdir(const char *dir);
 
 void msg_warn_file_not_found(const char *file);
+
+void verbose_printf(const int min_level, const char *fmt, ...)
+  __attribute__((format(printf, 2, 3)));

--- a/src/purging.c
+++ b/src/purging.c
@@ -50,8 +50,7 @@ is_time_to_purge(st_time *st_time_var, const char *file)
 
     if (fgets(time_prev, sizeof time_prev, fp) == NULL)
     {
-      print_msg_error();
-      printf("while getting line from %s\n", file);
+      diag(DIAG_ERR, "while getting line from %s\n", file);
       perror(__func__);
       close_file(&fp, file, __func__);
       exit(EXIT_FAILURE);
@@ -104,8 +103,7 @@ get_then_time(const char *tinfo_file)
     free(raw_deletion_date);
     return mktime(&tm_then);
   }
-  print_msg_error();
-  fprintf(stderr, "while getting deletion date from %s.\n", tinfo_file);
+  diag(DIAG_ERR, "while getting deletion date from %s.\n", tinfo_file);
   return 0;
 }
 
@@ -157,8 +155,7 @@ do_file_purge(char *purge_target, const rmw_options *cli_user_options,
   bool is_dir = is_dir_f(purge_target);
 
   int status = 0;
-  if (verbose)
-    printf("removing '%s\n", purge_target);
+  verbose_printf(1, "removing '%s'\n", purge_target);
 
   if (!is_dir)
   {
@@ -185,8 +182,7 @@ do_file_purge(char *purge_target, const rmw_options *cli_user_options,
     if (!status)
     {
       (*ctr)++;
-      if (verbose)
-        printf("-%s\n", pt_basename);
+      verbose_printf(1, "-%s\n", pt_basename);
     }
     else
       msg_err_remove(trashinfo_entry_realpath, __func__);
@@ -409,10 +405,7 @@ orphan_maint(st_waste *waste_head, st_time *st_time_var, int *orphan_ctr)
         (*orphan_ctr)++;
       }
       else
-      {
-        print_msg_error();
-        printf(_("while creating %s\n"), path_to_trashinfo);
-      }
+        diag(DIAG_ERR, _("while creating %s\n"), path_to_trashinfo);
       free(st_file_properties.real_path);
 
     }

--- a/src/restore.c
+++ b/src/restore.c
@@ -50,10 +50,7 @@ get_waste_parent(char *waste_parent, const char *src)
   free(waste_parent_rel_path);
 
   if (tmp == NULL)
-  {
-    perror("::realpath");
-    exit(errno);
-  }
+    diag_fatal(errno, "realpath: %s\n", strerror(errno));
 
   sn_check(strlen(tmp) + 1, PATH_MAX);
   strcpy(waste_parent, tmp);
@@ -113,8 +110,7 @@ restore(const char *src, st_time *st_time_var,
 
     if (!waste_match)
     {
-      print_msg_error();
-      fprintf(stderr, "'%s' is not in a Waste directory.\n", src);
+      diag(DIAG_ERR, "'%s' is not in a Waste directory.\n", src);
       return -1;
     }
 
@@ -163,8 +159,7 @@ restore(const char *src, st_time *st_time_var,
                  __func__, __LINE__);
       strcat(dest, st_time_var->suffix_added_dup_exists);
 
-      if (verbose)
-        printf(_("\
+      verbose_printf(1, _("\
 Duplicate filename at destination - appending time string...\n"));
     }
 
@@ -209,12 +204,9 @@ Duplicate filename at destination - appending time string...\n"));
         result = remove(src_tinfo);
 
       if (result != 0)
-      {
-        print_msg_error();
-        printf(_("while removing .trashinfo file: '%s'\n"), src_tinfo);
-      }
-      else if (verbose >= 2)
-        printf("-%s\n", src_tinfo);
+        diag(DIAG_ERR, _("while removing .trashinfo file: '%s'\n"), src_tinfo);
+      else
+        verbose_printf(2, "-%s\n", src_tinfo);
     }
     else
     {
@@ -226,8 +218,7 @@ Duplicate filename at destination - appending time string...\n"));
   {
     if (p_state == ENOENT)
     {
-      print_msg_warn();
-      msg_warn_file_not_found(src);
+      diag(DIAG_WARN, "'%s': %s\n", src, strerror(ENOENT));
       return ENOENT;
     }
     else
@@ -325,7 +316,7 @@ get_nearest_waste(st_waste *waste_head)
 
   if (getcwd(cwdbuf, sizeof cwdbuf) == NULL)
   {
-    perror("getcwd");
+    diag(DIAG_ERR, "getcwd: %s\n", strerror(errno));
     return NULL;
   }
 
@@ -455,10 +446,9 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
       if (my_items[n_choices] == NULL)
       {
         endwin();
-        fprintf(stderr, "new_item: %s\n\
-%s\n", strerror(errno), m_dir_entry);
+        diag(DIAG_ERR, "new_item: %s\n%s\n", strerror(errno), m_dir_entry);
         if (closedir(waste_dir))
-          perror("closedir");
+          diag(DIAG_ERR, "closedir: %s\n", strerror(errno));
         free(my_items);
         dispose_waste(waste_head);
         exit(EXIT_FAILURE);

--- a/src/trashinfo.c
+++ b/src/trashinfo.c
@@ -76,12 +76,10 @@ create_trashinfo(rmw_target *st_f_props, st_waste *waste_curr,
       {
         close_file(&fp, final_info_dest, __func__);
         if (unlink(final_info_dest) != 0)
-          perror("unlink");
-        print_msg_error();
-        fprintf(stderr, "Expected a leading '/' in the pathname '%s'\n",
-                escaped_path_ptr);
-        free(escaped_path);
-        exit(EXIT_FAILURE);
+          diag(DIAG_ERR, "unlink: %s\n", strerror(errno));
+        diag_fatal(EXIT_FAILURE,
+                   "Expected a leading '/' in the pathname '%s'\n",
+                   escaped_path_ptr);
       }
     }
 
@@ -99,18 +97,12 @@ create_trashinfo(rmw_target *st_f_props, st_waste *waste_curr,
     free(escaped_path);
 
     if (n < 0)
-    {
-      print_msg_error();
-      fprintf(stderr, "fprintf() failed due to an error writing to %s\n",
-              final_info_dest);
-    }
+      diag(DIAG_ERR, "fprintf() failed due to an error writing to %s\n",
+           final_info_dest);
     else if (n != want_size)
-    {
-      print_msg_error();
-      fprintf(stderr,
-              "Expected to write %zu bytes, but wrote %d bytes to %s\n",
-              want_size, n, final_info_dest);
-    }
+      diag(DIAG_ERR,
+           "Expected to write %zu bytes, but wrote %d bytes to %s\n",
+           want_size, n, final_info_dest);
     return close_file(&fp, final_info_dest, __func__);
   }
   else

--- a/test/test_basic.sh
+++ b/test/test_basic.sh
@@ -66,7 +66,7 @@ test "$output" = "6"
 
 echo "$SEPARATOR"
 echo "  == rmw should refuse to move a waste folder or a file that resides within a waste folder"
-output="$($RMW_TEST_CMD_STRING "$PRIMARY_WASTE_DIR"/info || true)"
+output="$($RMW_TEST_CMD_STRING "$PRIMARY_WASTE_DIR"/info 2>&1 || true)"
 expected=" :warning: ${PRIMARY_WASTE_DIR}/info resides within a waste folder and has been ignored
 0 items were removed to the waste folder"
 test "${output}" = "${expected}"


### PR DESCRIPTION
Introduces three variadic helpers in messages.c to replace the scattered `if (verbose) printf(...)`, `print_msg_error()+fprintf(stderr,...)`, and `perror()+exit()` patterns:

  - verbose_printf(min_level, fmt, ...) — gated on the global verbose level
  - diag(DIAG_ERR|DIAG_WARN, fmt, ...) — prefixed diagnostic to stderr
  - diag_fatal(exit_code, fmt, ...) — :error: prefix then exit(); noreturn

All three use __attribute__((format(printf, ...))) for compile-time format checking.

Migrated call sites in main.c, purging.c, ficlone.c, restore.c, and trashinfo.c. The msg_err_* family is left in place for now; in-progress branches still rely on it.

Behavior change: warnings now go to stderr instead of stdout (the old print_msg_warn() wrote to stdout, corrupting pipelines). test_basic.sh updated to capture stderr for the affected assertion. Also fixes a typo in the purging "removing '%s'" verbose message.