### PR TITLE
Move BTRFS_SUPER_MAGIC out of ficlone.h

### DIFF
--- a/src/ficlone.c
+++ b/src/ficlone.c
@@ -39,6 +39,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef BCACHEFS_SUPER_MAGIC
 #define BCACHEFS_SUPER_MAGIC 0xca451a4e
 #endif
+
+#ifndef BTRFS_SUPER_MAGIC
+#define BTRFS_SUPER_MAGIC 0x9123683E
+#endif
 #endif
 
 #include "ficlone.h"

--- a/src/ficlone.h
+++ b/src/ficlone.h
@@ -23,8 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdbool.h>
 
-#define BTRFS_SUPER_MAGIC 0x9123683E
-
 bool is_ficlone_fs(const char *path);
 
 int ficlone_move(const char *src, const char *dst);


### PR DESCRIPTION
This symbol is not used outside of ficlone.c.