### PR TITLE
topdir: scan all mounts only when the command needs it

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -915,7 +915,37 @@ Please check your configuration file and permissions\
   else
     run_discovery = getenv(ENV_RMW_FAKE_HOME) == NULL
       || getenv(ENV_RMW_CHECK_DISCOVERY) != NULL;
-  if (run_discovery)
+
+  /* Only commands that act on every trash need the full mount scan; probing
+   * all mounts can stall while an idle USB drive resumes (issue #574). A plain
+   * removal skips it: remove_to_waste()'s per-file fallback probes only the
+   * mount the file lives on (already awake). An explicit --purge scans, but the
+   * automatic time-based purge that piggybacks on a removal deliberately does
+   * not, so removals never wake another drive. */
+  bool command_needs_discovery = cli_user_options.list
+    || cli_user_options.want_restore
+    || cli_user_options.want_selection_menu
+    || cli_user_options.most_recent_list
+    || cli_user_options.want_undo
+    || cli_user_options.want_orphan_chk
+    || cli_user_options.want_purge;
+
+  /* A reflink-capable source can be routed cross-mount into a pre-existing
+     trash on a sibling reflink filesystem, which only the full scan can find.
+     So a plain removal still probes when any file being removed lives on such
+     a filesystem; a removal from a non-reflink fs skips the scan (issue #574
+     -- avoids waking an idle drive for the common home-trash case). */
+  if (run_discovery && !command_needs_discovery)
+  {
+    for (int i = optind; i < argc; i++)
+      if (is_ficlone_fs(argv[i]))
+      {
+        command_needs_discovery = true;
+        break;
+      }
+  }
+
+  if (run_discovery && command_needs_discovery)
     discover_existing_topdir_trashes(&st_config_data, st_location);
 
   if (cli_user_options.list)

--- a/src/topdir_trash.c
+++ b/src/topdir_trash.c
@@ -290,14 +290,26 @@ find_topdir_trash(const char *file_path, const char *uid,
 
   /* Never create a trash dir on an excluded filesystem (tmpfs, network
    * shares, ...). Desktop file managers refuse to trash there too; the
-   * caller reports that no suitable waste folder exists. A pre-existing
-   * trash on such a mount is honored via build_mount_trash_list instead. */
+   * caller then reports that no suitable waste folder exists. An existing
+   * trash on such a mount is still honored (see below). */
   char *result = NULL;
-  if (best != NULL && mount_is_eligible(best))
+  if (best != NULL)
   {
-    result = trash_path_for_topdir(topdir, uid);
-    if (result != NULL && mount_path_out != NULL)
-      *mount_path_out = strdup(topdir);
+    char *candidate = trash_path_for_topdir(topdir, uid);
+    /* New trash dirs are only created on eligible mounts. On an excluded
+       mount (tmpfs, network share) rmw never creates one, but an existing,
+       writable trash there is still honored -- the same rule discovery
+       (build_mount_trash_list) applies, scoped here to the file's own mount
+       so no other mount is probed (issue #574). */
+    if (candidate != NULL
+        && (mount_is_eligible(best) || access(candidate, W_OK) == 0))
+    {
+      result = candidate;
+      if (mount_path_out != NULL)
+        *mount_path_out = strdup(topdir);
+    }
+    else
+      free(candidate);
   }
 
   g_list_free_full(mounts, (GDestroyNotify) g_unix_mount_free);


### PR DESCRIPTION
Fixes #574