### PR TITLE
restore: choose the -s start waste by device, not path prefix

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -146,6 +146,14 @@ items from your waste (or trash) directories after x number of days.
     space bar to select the items you wish to restore, then press enter to
     restore all selected items.
 
+    The list opens on the waste directory of your current filesystem. If
+    no waste directory is on that filesystem, it opens on the first one in
+    your list instead.
+
+    When the output is not a terminal (for example, piped to another
+    program), rmw does not open the menu. Instead it prints the path of
+    that waste directory, followed by the names of the items in it.
+
 `-u`, `--undo-last`
 : undo last move
 

--- a/rmw.1
+++ b/rmw.1
@@ -146,6 +146,14 @@ left/right cursor keys to switch between waste directories. Use the
 space bar to select the items you wish to restore, then press enter to
 restore all selected items.
 
+The list opens on the waste directory of your current filesystem. If
+no waste directory is on that filesystem, it opens on the first one in
+your list instead.
+
+When the output is not a terminal (for example, piped to another
+program), rmw does not open the menu. Instead it prints the path of
+that waste directory, followed by the names of the items in it.
+
 .TP
 \fB-u\fR, \fB--undo-last\fR
 undo last move

--- a/src/main.c
+++ b/src/main.c
@@ -985,15 +985,9 @@ Please check your configuration file and permissions\
 
   if (cli_user_options.want_selection_menu)
   {
-    int r = 0;
-#if !defined DISABLE_CURSES
-    r =
+    int r =
       restore_select(st_config_data.st_waste_folder_props_head, &st_time_var,
                      &cli_user_options);
-#else
-    printf("This rmw was built without menu support\n");
-    r = 0;
-#endif
     dispose_waste(st_config_data.st_waste_folder_props_head);
     return r;
   }

--- a/src/restore.c
+++ b/src/restore.c
@@ -302,21 +302,32 @@ insertion_sort(ITEM **a, const int n)
 
 
 /*
- * Returns the waste node whose parent path is "nearest" to dir: the one
- * sharing the longest path-component prefix with it. A waste nested below
- * dir is not eligible -- such a trash serves a subdirectory, not the
- * location dir is in (this matters now that discovery can add trashes from
- * deep in the tree). Returns NULL if waste_head is NULL or nothing shares a
- * path component with dir.
+ * Returns the waste node on the same filesystem as dir (matched by device
+ * number, dir_dev), best fitting dir. Among the same-device wastes it picks
+ * the one sharing the longest path-component prefix with dir. Returns NULL if
+ * no waste is on dir's filesystem.
+ *
+ * Device matching, not string prefix alone, is what issue #532 asked for
+ * ("the trash of the current filesystem"): a $topdir trash on another mount
+ * has a different st_dev and is excluded even when its path shares a prefix,
+ * and the home trash is chosen from anywhere on the home filesystem even
+ * though its own path sits below the current directory.
+ *
+ * Ties keep the first node in list order, which preserves rmw's "configured
+ * waste preferred over auto-discovered" rule: config entries precede the
+ * discovered nodes, and the discovered home trash precedes discovered topdirs.
  */
 static st_waste *
-get_nearest_waste(st_waste *waste_head, const char *dir)
+get_nearest_waste(st_waste *waste_head, const char *dir, dev_t dir_dev)
 {
   st_waste *best = NULL;
-  size_t best_len = 0;
+  size_t best_score = 0;
 
   for (st_waste * curr = waste_head; curr != NULL; curr = curr->next_node)
   {
+    if (curr->dev_num != dir_dev)
+      continue;
+
     const char *p = curr->parent;
     size_t i = 0;
     size_t last_sep = 0;
@@ -328,18 +339,19 @@ get_nearest_waste(st_waste *waste_head, const char *dir)
       i++;
     }
 
-    /* Skip a waste nested below dir (dir is a path prefix of the waste's
-     * parent): it serves a subdirectory, not where we are. */
-    if (dir[i] == '\0' && p[i] == '/')
-      continue;
-
-    /* The waste's parent is itself a path prefix of dir: count all of it. */
+    /* Full credit only when the waste's directory contains dir (its parent is
+       an ancestor of, or equal to, dir). A waste nested below dir serves a
+       subdirectory, not where we are, so it gets only weak credit (up to the
+       last shared separator) and loses the tie-break to an earlier trash. */
+    size_t score;
     if (p[i] == '\0' && (dir[i] == '/' || dir[i] == '\0'))
-      last_sep = i;
+      score = i;
+    else
+      score = last_sep;
 
-    if (last_sep > best_len)
+    if (best == NULL || score > best_score)
     {
-      best_len = last_sep;
+      best_score = score;
       best = curr;
     }
   }
@@ -363,7 +375,13 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   char cwdbuf[PATH_MAX];
   st_waste *waste_curr = NULL;
   if (getcwd(cwdbuf, sizeof cwdbuf) != NULL)
-    waste_curr = get_nearest_waste(waste_head, cwdbuf);
+  {
+    struct stat cwd_st;
+    if (stat(cwdbuf, &cwd_st) == 0)
+      waste_curr = get_nearest_waste(waste_head, cwdbuf, cwd_st.st_dev);
+    else
+      diag(DIAG_ERR, "stat: %s: %s\n", cwdbuf, strerror(errno));
+  }
   else
     diag(DIAG_ERR, "getcwd: %s\n", strerror(errno));
   if (waste_curr == NULL)
@@ -640,31 +658,64 @@ test_create_file_details_str(void)
 static void
 test_get_nearest_waste(void)
 {
-  /* Only ->parent and ->next_node are read by get_nearest_waste(). */
+  /* get_nearest_waste() only reads ->parent, ->dev_num, and ->next_node and
+     does no filesystem I/O, so the paths below are pure fixtures -- they need
+     not exist on disk. Devices: HOME = home filesystem, SUB = a separately-
+     mounted subvolume, FLASH = a removable mount. The list is in realistic
+     order: configured wastes first, then the discovered nodes (home trash
+     before topdirs). "cfg" and "work" sit on the home fs; "child" and "flash"
+     are discovered topdirs on their own mounts. "cfg" is a no-add configured
+     trash (still a valid restore start). */
+  enum { DEV_HOME = 1, DEV_SUB = 2, DEV_FLASH = 3, DEV_NONE = 4 };
+  st_waste cfg = { 0 };
+  st_waste work = { 0 };
   st_waste home = { 0 };
   st_waste child = { 0 };
   st_waste flash = { 0 };
-  home.parent = "/home/andy/.local/share/Trash";
-  child.parent = "/home/andy/src/rmw-project/.Trash-1000";
+  cfg.parent = "/home/u/.config-trash";
+  cfg.dev_num = DEV_HOME;
+  cfg.no_add = true;
+  work.parent = "/home/u/work";
+  work.dev_num = DEV_HOME;
+  home.parent = "/home/u/.local/share/Trash";
+  home.dev_num = DEV_HOME;
+  child.parent = "/mnt/sub/.Trash-1000";
+  child.dev_num = DEV_SUB;
   flash.parent = "/mnt/flash/.Trash-1000";
+  flash.dev_num = DEV_FLASH;
 
-  /* List the deep child first -- the order that exposed the bug. */
-  child.next_node = &home;
-  home.next_node = &flash;
-  st_waste *head = &child;
+  cfg.next_node = &work;
+  work.next_node = &home;
+  home.next_node = &child;
+  child.next_node = &flash;
+  st_waste *head = &cfg;
 
-  /* From ~/src the child trash is *below* the cwd, so it must be skipped;
-   * the home trash wins even though the child is listed first. */
-  assert(get_nearest_waste(head, "/home/andy/src") == &home);
+  /* From the home dir: every home-fs waste is nested below cwd, so they tie
+     and list order decides -- the configured trash wins over the discovered
+     home trash (config preferred over auto-discovered). */
+  assert(get_nearest_waste(head, "/home/u", DEV_HOME) == &cfg);
 
-  /* Inside the child's own subtree, the child trash is nearest. */
-  assert(get_nearest_waste(head, "/home/andy/src/rmw-project/sub") == &child);
+  /* Deeper into the home tree: still a home-fs tie, still the earliest one. */
+  assert(get_nearest_waste(head, "/home/u/src", DEV_HOME) == &cfg);
 
-  /* On the flash mount, its trash is nearest. */
-  assert(get_nearest_waste(head, "/mnt/flash/docs") == &flash);
+  /* Device match wins even with no shared path prefix at all: a home-fs cwd
+     outside every waste's path still selects the earliest home-fs waste
+     (the case the old prefix-only code returned NULL for). */
+  assert(get_nearest_waste(head, "/opt/foo", DEV_HOME) == &cfg);
 
-  /* An unrelated directory shares no path component: no match. */
-  assert(get_nearest_waste(head, "/var/tmp") == NULL);
+  /* From inside a WASTE's own directory, that waste's longer path prefix beats
+     the earlier-listed cfg: containment outranks list order. */
+  assert(get_nearest_waste(head, "/home/u/work/proj", DEV_HOME) == &work);
+
+  /* Inside the subvolume mount: the device match selects its topdir trash,
+     even though home-fs wastes are listed first (they're another filesystem). */
+  assert(get_nearest_waste(head, "/mnt/sub/proj", DEV_SUB) == &child);
+
+  /* On the flash mount, its trash is nearest by device. */
+  assert(get_nearest_waste(head, "/mnt/flash/docs", DEV_FLASH) == &flash);
+
+  /* A directory on a filesystem with no waste: no match. */
+  assert(get_nearest_waste(head, "/var/tmp", DEV_NONE) == NULL);
 
   return;
 }

--- a/src/restore.c
+++ b/src/restore.c
@@ -360,6 +360,38 @@ get_nearest_waste(st_waste *waste_head, const char *dir, dev_t dir_dev)
 }
 
 
+/*
+ * Non-interactive fallback for restore_select() when stdout is not a terminal
+ * (piped or redirected, e.g. under the test suite). The ncurses menu cannot
+ * run there, so print the active waste's path followed by its entries, sorted,
+ * instead. This makes the "-s starts on the current filesystem's trash"
+ * behavior scriptable and testable. See issue #532.
+ */
+static int
+dump_active_waste(const st_waste *waste)
+{
+  printf("%s\n", waste->parent);
+
+  struct dirent **namelist;
+  int n = scandir(waste->files, &namelist, NULL, alphasort);
+  if (n < 0)
+  {
+    msg_err_open_dir(waste->files, __func__, __LINE__);
+    return errno;
+  }
+
+  for (int i = 0; i < n; i++)
+  {
+    if (!isdotdir(namelist[i]->d_name))
+      printf("%s\n", namelist[i]->d_name);
+    free(namelist[i]);
+  }
+  free(namelist);
+
+  return 0;
+}
+
+
 /*!
  * Displays a list of files that can be restored, user can select multiple
  * files using a curses-bases interface.
@@ -386,6 +418,12 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
     diag(DIAG_ERR, "getcwd: %s\n", strerror(errno));
   if (waste_curr == NULL)
     waste_curr = waste_head;
+
+  /* Not a terminal (piped/redirected): the ncurses menu can't run, so dump
+     the active waste non-interactively instead. */
+  if (!isatty(STDOUT_FILENO))
+    return dump_active_waste(waste_curr);
+
   const int start_line_bottom = 7;
   const int min_lines_required = start_line_bottom + 3;
   int c = 0;

--- a/src/restore.c
+++ b/src/restore.c
@@ -313,7 +313,10 @@ insertion_sort(ITEM **a, const int n)
  * and the home trash is chosen from anywhere on the home filesystem even
  * though its own path sits below the current directory.
  *
- * Ties keep the first node in list order, which preserves rmw's "configured
+ * A waste nested below dir serves a subdirectory, not where we are, so any
+ * non-nested same-device waste beats it regardless of score; nested wastes
+ * are chosen only when nothing else is on dir's filesystem. Within a tier,
+ * ties keep the first node in list order, which preserves rmw's "configured
  * waste preferred over auto-discovered" rule: config entries precede the
  * discovered nodes, and the discovered home trash precedes discovered topdirs.
  */
@@ -322,6 +325,7 @@ get_nearest_waste(st_waste *waste_head, const char *dir, dev_t dir_dev)
 {
   st_waste *best = NULL;
   size_t best_score = 0;
+  bool best_nested = true;
 
   for (st_waste * curr = waste_head; curr != NULL; curr = curr->next_node)
   {
@@ -339,19 +343,24 @@ get_nearest_waste(st_waste *waste_head, const char *dir, dev_t dir_dev)
       i++;
     }
 
+    /* Nested: dir is a proper ancestor of the waste's parent. */
+    bool nested = (dir[i] == '\0' && p[i] == '/');
+
     /* Full credit only when the waste's directory contains dir (its parent is
-       an ancestor of, or equal to, dir). A waste nested below dir serves a
-       subdirectory, not where we are, so it gets only weak credit (up to the
-       last shared separator) and loses the tie-break to an earlier trash. */
+       an ancestor of, or equal to, dir); otherwise credit the shared prefix
+       up to the last path separator. */
     size_t score;
     if (p[i] == '\0' && (dir[i] == '/' || dir[i] == '\0'))
       score = i;
     else
       score = last_sep;
 
-    if (best == NULL || score > best_score)
+    if (best == NULL
+        || (!nested && best_nested)
+        || (nested == best_nested && score > best_score))
     {
       best_score = score;
+      best_nested = nested;
       best = curr;
     }
   }
@@ -376,8 +385,10 @@ dump_active_waste(const st_waste *waste)
   int n = scandir(waste->files, &namelist, NULL, alphasort);
   if (n < 0)
   {
+    /* the message call writes to stderr, which may change errno */
+    int err = errno;
     msg_err_open_dir(waste->files, __func__, __LINE__);
-    return errno;
+    return err;
   }
 
   for (int i = 0; i < n; i++)
@@ -418,6 +429,13 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
     diag(DIAG_ERR, "getcwd: %s\n", strerror(errno));
   if (waste_curr == NULL)
     waste_curr = waste_head;
+  /* Possible with an empty config when discovery is off or finds nothing;
+     both the dump and the menu need a waste to browse. */
+  if (waste_curr == NULL)
+  {
+    puts(_("No waste folders are available."));
+    return 0;
+  }
 
   /* Not a terminal (piped/redirected): the ncurses menu can't run, so dump
      the active waste non-interactively instead. */
@@ -754,6 +772,20 @@ test_get_nearest_waste(void)
 
   /* A directory on a filesystem with no waste: no match. */
   assert(get_nearest_waste(head, "/var/tmp", DEV_NONE) == NULL);
+
+  /* A same-device waste nested below the cwd loses to a non-nested one even
+     when listed first: it serves a subdirectory, not where we are. */
+  st_waste below = { 0 };
+  st_waste home2 = { 0 };
+  below.parent = "/home/u/src/proj/.waste";
+  below.dev_num = DEV_HOME;
+  home2.parent = "/home/u/.local/share/Trash";
+  home2.dev_num = DEV_HOME;
+  below.next_node = &home2;
+  assert(get_nearest_waste(&below, "/home/u/src", DEV_HOME) == &home2);
+
+  /* ...but when every same-device waste is nested, the first one wins. */
+  assert(get_nearest_waste(&below, "/home/u", DEV_HOME) == &below);
 
   return;
 }

--- a/src/restore.c
+++ b/src/restore.c
@@ -299,6 +299,7 @@ insertion_sort(ITEM **a, const int n)
   }
   return;
 }
+#endif
 
 
 /*
@@ -438,10 +439,17 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
   }
 
   /* Not a terminal (piped/redirected): the ncurses menu can't run, so dump
-     the active waste non-interactively instead. */
+     the active waste non-interactively instead. This path works in every
+     build, so -s stays scriptable even without curses. */
   if (!isatty(STDOUT_FILENO))
     return dump_active_waste(waste_curr);
 
+#if defined DISABLE_CURSES
+  (void) st_time_var;
+  (void) cli_user_options;
+  printf("This rmw was built without menu support\n");
+  return 0;
+#else
   const int start_line_bottom = 7;
   const int min_lines_required = start_line_bottom + 3;
   int c = 0;
@@ -644,8 +652,8 @@ restore_select(st_waste *waste_head, st_time *st_time_var,
     endwin();
 
   return restore_err_ctr;
-}
 #endif
+}
 
 /*!
  * Restores files from the mrl
@@ -710,6 +718,7 @@ test_create_file_details_str(void)
 
   return;
 }
+#endif
 
 static void
 test_get_nearest_waste(void)
@@ -789,15 +798,14 @@ test_get_nearest_waste(void)
 
   return;
 }
-#endif
 
 int
 main(void)
 {
 #if !defined DISABLE_CURSES
   test_create_file_details_str();
-  test_get_nearest_waste();
 #endif
+  test_get_nearest_waste();
   return 0;
 }
 #endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,8 @@ scripts = [
   'test_media_root.sh',
   'test_purging.sh',
   'test_restore.sh',
+  'test_restore_select.sh',
+  'test_restore_select_multifs.sh',
   'test_waste_negation.sh',
   'test_discovery.sh',
   'test_config_optional.sh',

--- a/test/test_restore_select.sh
+++ b/test/test_restore_select.sh
@@ -16,13 +16,6 @@ else
   . "${MESON_SOURCE_ROOT}/test/COMMON"
 fi
 
-# The -s dump lives in the ncurses restore-menu code; a build without curses
-# just prints "built without menu support", so there is nothing to check.
-if grep -q "DISABLE_CURSES" "$MESON_BUILD_ROOT/src/config.h" 2>/dev/null; then
-  echo "built without curses; skipping -s dump test."
-  exit "$SKIP"
-fi
-
 # First run creates the waste directories.
 $RMW_TEST_CMD_STRING
 

--- a/test/test_restore_select.sh
+++ b/test/test_restore_select.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# test_restore_select.sh: the non-interactive fallback for 'rmw -s'. When
+# stdout is not a terminal (piped/redirected, as under 'meson test'), the
+# ncurses menu can't run, so -s dumps the active waste -- the trash on the
+# current filesystem -- and its contents instead. This is the scriptable,
+# testable form of the "-s starts on the current filesystem" behavior (#532).
+#
+# Single filesystem, no privileges: this covers the dump plumbing and format.
+# The cross-filesystem selection is covered by test_restore_select_multifs.sh.
+
+set -ve
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+# The -s dump lives in the ncurses restore-menu code; a build without curses
+# just prints "built without menu support", so there is nothing to check.
+if grep -q "DISABLE_CURSES" "$MESON_BUILD_ROOT/src/config.h" 2>/dev/null; then
+  echo "built without curses; skipping -s dump test."
+  exit "$SKIP"
+fi
+
+# First run creates the waste directories.
+$RMW_TEST_CMD_STRING
+
+cd "${RMW_FAKE_HOME}"
+echo data > alpha
+echo data > beta
+# Both files are on the home filesystem, so they land in the first waste
+# configured there ($HOME/.Waste).
+$RMW_TEST_CMD_STRING alpha beta
+
+# stdout is captured (not a tty), so -s takes the dump path.
+out=$($RMW_TEST_CMD_STRING -s)
+printf '%s\n' "$out"
+
+# Line 1 is the active waste: the trash on the current filesystem, not a
+# removable or other-filesystem waste listed in the config.
+active=$(printf '%s\n' "$out" | head -n 1)
+test "$active" = "${RMW_FAKE_HOME}/.Waste"
+
+# ...and its contents are listed.
+cmp_substr "$out" "alpha"
+cmp_substr "$out" "beta"
+
+echo "PASS: -s without a tty dumped the current filesystem's waste"
+exit 0

--- a/test/test_restore_select_multifs.sh
+++ b/test/test_restore_select_multifs.sh
@@ -25,13 +25,6 @@ else
   . "${MESON_SOURCE_ROOT}/test/COMMON"
 fi
 
-# The -s dump lives in the ncurses restore-menu code; a build without curses
-# just prints "built without menu support", so there is nothing to check.
-if grep -q "DISABLE_CURSES" "$MESON_BUILD_ROOT/src/config.h" 2>/dev/null; then
-  echo "built without curses; skipping -s dump test."
-  exit "$SKIP"
-fi
-
 ROOT="/tmp/rmw-select-multifs"
 A="$ROOT/a"                    # its own tmpfs (distinct device)
 B="$ROOT/b"                    # a second tmpfs (another device)

--- a/test/test_restore_select_multifs.sh
+++ b/test/test_restore_select_multifs.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# test_restore_select_multifs.sh: 'rmw -s' (non-tty dump) must select the trash
+# on the CURRENT filesystem when several wastes exist -- the behavior issue #532
+# asked for. Exercised across two real mounts the test fully controls inside an
+# unprivileged mount namespace (no sudo). SKIP where namespaces are unavailable.
+#
+# Everything lives on private tmpfs mounts that vanish when the namespace exits.
+
+set -ve
+
+# Re-exec inside a private mount namespace (mapped to root so mount works)
+# before sourcing COMMON, so COMMON runs exactly once. If unprivileged
+# user/mount namespaces are unavailable, skip (77).
+if [ -z "$RMW_SELECT_NS" ]; then
+  if ! unshare --mount --map-root-user true 2>/dev/null; then
+    echo "unprivileged mount namespace unavailable; skipping."
+    exit 77
+  fi
+  RMW_SELECT_NS=1 exec unshare --mount --map-root-user "$0" "$@"
+fi
+
+if [ -e COMMON ]; then
+  . ./COMMON
+else
+  . "${MESON_SOURCE_ROOT}/test/COMMON"
+fi
+
+# The -s dump lives in the ncurses restore-menu code; a build without curses
+# just prints "built without menu support", so there is nothing to check.
+if grep -q "DISABLE_CURSES" "$MESON_BUILD_ROOT/src/config.h" 2>/dev/null; then
+  echo "built without curses; skipping -s dump test."
+  exit "$SKIP"
+fi
+
+ROOT="/tmp/rmw-select-multifs"
+A="$ROOT/a"                    # its own tmpfs (distinct device)
+B="$ROOT/b"                    # a second tmpfs (another device)
+rm -rf "$ROOT"
+mkdir -p "$A" "$B"
+mount -t tmpfs none "$A"
+mount -t tmpfs none "$B"
+mkdir -p "$A/waste" "$B/waste"
+
+# A configured waste on each filesystem.
+CONFIG="$RMW_FAKE_HOME/select-multifs.testrc"
+mkdir -p "$RMW_FAKE_HOME"
+printf 'WASTE = %s/waste\nWASTE = %s/waste\nexpire_age = 30\n' "$A" "$B" \
+  > "$CONFIG"
+RMW="$BIN_DIR/rmw -c $CONFIG"
+
+# A file on each filesystem, removed to that filesystem's waste.
+echo data > "$A/file_a"
+echo data > "$B/file_b"
+$RMW "$A/file_a"
+$RMW "$B/file_b"
+
+# From mount A, the active (nearest-by-device) waste is A's, listing file_a.
+cd "$A"
+out=$($RMW -s)
+printf '%s\n' "$out"
+test "$(printf '%s\n' "$out" | head -n 1)" = "$A/waste"
+cmp_substr "$out" "file_a"
+
+# From mount B, the active waste is B's, listing file_b. The configured order
+# (A before B) does not override the current filesystem.
+cd "$B"
+out=$($RMW -s)
+printf '%s\n' "$out"
+test "$(printf '%s\n' "$out" | head -n 1)" = "$B/waste"
+cmp_substr "$out" "file_b"
+
+echo "PASS: -s selected the current filesystem's waste on each mount"
+exit 0


### PR DESCRIPTION
Fixes #532