### PR TITLE
build: keep the curses and menu choices from disagreeing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 
 rmw (in-progress):
+  * build: pick the curses and menu libraries so they cannot disagree, and
+    probe the curses headers against the library that was found rather than
+    against whatever exists on the system (#579)
   * verbose: the startup path/diagnostic lines (home_dir, config_file,
     discovered topdir trashes, ficlone support, etc.) now require -vv; plain
     -v keeps only the per-file action messages

--- a/meson.build
+++ b/meson.build
@@ -44,23 +44,6 @@ conf.set_quoted(
   'https://github.com/theimpossibleastronaut/rmw/issues',
 )
 
-check_headers = [
-  ['ncursesw/menu.h', 'HAVE_NCURSESW_MENU_H'],
-  ['ncurses/menu.h', 'HAVE_NCURSES_MENU_H'],
-  ['menu.h', 'HAVE_MENU_H'],
-  ['ncursesw/curses.h', 'HAVE_NCURSESW_CURSES_H'],
-  ['ncursesw.h', 'HAVE_NCURSESW_H'],
-  ['ncurses/curses.h', 'HAVE_NCURSES_CURSES_H'],
-  ['ncurses.h', 'HAVE_NCURSES_H'],
-  ['curses.h', 'HAVE_CURSES_H'],
-]
-
-foreach h : check_headers
-  if cc.has_header(h[0])
-    conf.set(h[1], 1)
-  endif
-endforeach
-
 localedir = join_paths(get_option('prefix'), get_option('localedir'))
 subdir('po')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,23 +3,63 @@ disable_curses = ''
 dep_menu = []
 dep_curses = []
 if not get_option('without-curses')
+  # Meson's curses dependency has a SYSTEM method of its own, so this resolves
+  # even where no pkg-config files exist for it.
   dep_curses = dependency('curses')
+
+  # The menu library ships with ncurses but is separate to the linker, and meson
+  # has no menu dependency, so it has to be looked for by hand. The order is
+  # deliberate:
+  #
+  #   menuw via pkg-config    matches the wide curses meson prefers, and is the
+  #                           only route that finds a keg-only Homebrew ncurses
+  #   the plain library names  need no pkg-config data at all; OpenBSD shipped
+  #                           none for these before 2025, and its single libmenu
+  #                           is already wide
+  #   dependency('menu') last  menu.pc names the narrow library in
+  #                           Requires.private, so it can pull a second curses
+  #                           into the link (mesonbuild/meson#8867)
   dep_menu = dependency('menuw', required: false)
   if not dep_menu.found()
+    dep_menu = cc.find_library('menuw', required: false)
+  endif
+  if not dep_menu.found()
+    dep_menu = cc.find_library('menu', required: false)
+  endif
+  if not dep_menu.found()
     dep_menu = dependency('menu', required: false)
-    if not dep_menu.found()
-      dep_menu = cc.find_library('menuw')
-      if not dep_menu.found()
-        dep_menu = cc.find_library('menu')
-        if not dep_menu.found()
-          conf.set('DISABLE_CURSES', 1)
-        endif
-      endif
-    endif
+  endif
+  if not dep_menu.found()
+    conf.set('DISABLE_CURSES', 1)
   endif
 else
   conf.set('DISABLE_CURSES', 1)
 endif
+
+# Probe each header against the curses that was actually found, rather than just
+# for the file being present. The HAVE_* names below are borrowed from
+# AX_WITH_CURSES, an autoconf-archive m4 macro that this project does not use and
+# does not ship -- only its define names were taken:
+#   https://gitweb.git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_with_curses.m4
+# There each one is set by a link test against the library the macro selected, so
+# it means "this header works with our curses". Passing dep_curses keeps that
+# meaning here. It is empty when curses is disabled, so that case is unchanged.
+check_headers = [
+  ['ncursesw/menu.h', 'HAVE_NCURSESW_MENU_H'],
+  ['ncurses/menu.h', 'HAVE_NCURSES_MENU_H'],
+  ['menu.h', 'HAVE_MENU_H'],
+  ['ncursesw/curses.h', 'HAVE_NCURSESW_CURSES_H'],
+  ['ncursesw.h', 'HAVE_NCURSESW_H'],
+  ['ncurses/curses.h', 'HAVE_NCURSES_CURSES_H'],
+  ['ncurses.h', 'HAVE_NCURSES_H'],
+  ['curses.h', 'HAVE_CURSES_H'],
+]
+
+foreach h : check_headers
+  if cc.has_header(h[0], dependencies: dep_curses)
+    conf.set(h[1], 1)
+  endif
+endforeach
 
 src = [
   'globals.c',


### PR DESCRIPTION
> Drafted by Claude (Opus 5), an LLM by Anthropic, at andy5995's
> direction.

Three lookups decided the curses flavour independently, so a build could pair the wide menu library with narrow curses, or compile against the wide header while linking the narrow library.

The menu chain is now flat and reordered. dependency('menu') goes last because menu.pc names the narrow library in Requires.private, which is what pulled a second curses into the link in mesonbuild/meson#8867; the plain library names come before it, since they need no pkg-config data at all and OpenBSD shipped none for these until 2025. Both find_library() calls now pass required: false -- without it the first one raised on any system lacking libmenuw, which made the remaining fallbacks and the DISABLE_CURSES path unreachable.

The header probes move next to the dependency and take it as an argument. AX_WITH_CURSES, where these defines come from, sets them from a link test against the library it selected, so they are meant to mean "this header works with our curses" rather than "this file exists somewhere".

Fixes #579