### PR TITLE
ci: test macOS on 15 and 26, arm64 and x86_64

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-15, macos-26, macos-26-intel]
 
     runs-on: ${{ matrix.os }}
     env:
@@ -137,6 +137,10 @@ jobs:
 
     - run: |
         brew update
+        # The macOS 15 image preinstalls openssl@1.1, which owns
+        # /opt/homebrew/bin/openssl and makes an openssl@3 upgrade (pulled in
+        # by meson) fail to link.
+        brew unlink openssl@1.1 || true
         brew install \
           canfigger \
           gettext \
@@ -144,7 +148,7 @@ jobs:
           meson \
           ninja \
           ncurses \
-          pkg-config \
+          pkg-config
 
     - name: Configure
       run: meson setup builddir
@@ -199,8 +203,7 @@ jobs:
           libglib2.0-dev \
           meson \
           ninja-build \
-          strace \
-          xvfb
+          strace
 
     - name: Configure with nls
       run: meson setup builddir


### PR DESCRIPTION
> Message drafted by Claude (Opus 5), an LLM by Anthropic, at
> andy5995's direction.

macos-14 is deprecated and, like macos-latest, is arm64 only. macOS 15 also brings clang 17 coverage against 26's clang 21.